### PR TITLE
OAuth (PKCE) login + per-repo revcat.toml

### DIFF
--- a/commands/auth/doctor.go
+++ b/commands/auth/doctor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/akshitkrnagpal/revcat/internal/api"
 	authstore "github.com/akshitkrnagpal/revcat/internal/auth"
+	"github.com/akshitkrnagpal/revcat/internal/cliutil"
 	"github.com/akshitkrnagpal/revcat/internal/output"
 )
 
@@ -43,7 +44,7 @@ func runAuthDoctor(cmd *cobra.Command, args []string) error {
 	}
 	checks = append(checks, check{name: "credential store", ok: true, msg: storeName + " accessible"})
 
-	profile, err := authstore.Resolve(store, "")
+	profile, err := authstore.Resolve(store, cliutil.Profile(cmd))
 	if err != nil {
 		checks = append(checks, check{name: "active profile", ok: false, msg: err.Error(), hint: "run `revcat auth login --name default --secret-key sk_...`"})
 		return renderChecks(checks)

--- a/commands/auth/doctor.go
+++ b/commands/auth/doctor.go
@@ -50,13 +50,28 @@ func runAuthDoctor(cmd *cobra.Command, args []string) error {
 	}
 	checks = append(checks, check{name: "active profile", ok: true, msg: profile.Name})
 
-	if !strings.HasPrefix(profile.SecretKey, "sk_") {
-		checks = append(checks, check{name: "key format", ok: false, msg: "stored key does not start with sk_", hint: "v2 secret keys begin with sk_; double-check it isn't a public SDK key"})
-	} else {
-		checks = append(checks, check{name: "key format", ok: true, msg: "looks like a v2 secret key"})
+	authType := profile.EffectiveAuthType()
+	checks = append(checks, check{name: "auth type", ok: true, msg: string(authType)})
+
+	opts := api.Options{ProjectID: profile.ProjectID, Version: cmd.Root().Version}
+	switch authType {
+	case authstore.AuthTypeOAuth:
+		if profile.AccessToken == "" {
+			checks = append(checks, check{name: "oauth token", ok: false, msg: "no access_token on profile", hint: "rerun `revcat auth login --oauth`"})
+		} else {
+			checks = append(checks, check{name: "oauth token", ok: true, msg: "present"})
+		}
+		opts.TokenSource = authstore.NewOAuthTokenSource(store, profile)
+	default:
+		if !strings.HasPrefix(profile.SecretKey, "sk_") {
+			checks = append(checks, check{name: "key format", ok: false, msg: "stored key does not start with sk_", hint: "v2 secret keys begin with sk_; double-check it isn't a public SDK key"})
+		} else {
+			checks = append(checks, check{name: "key format", ok: true, msg: "looks like a v2 secret key"})
+		}
+		opts.SecretKey = profile.SecretKey
 	}
 
-	client := api.New(api.Options{SecretKey: profile.SecretKey, ProjectID: profile.ProjectID, Version: cmd.Root().Version})
+	client := api.New(opts)
 	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 	defer cancel()
 	projects, apiErr := client.ListProjects(ctx)

--- a/commands/auth/doctor.go
+++ b/commands/auth/doctor.go
@@ -54,7 +54,8 @@ func runAuthDoctor(cmd *cobra.Command, args []string) error {
 	authType := profile.EffectiveAuthType()
 	checks = append(checks, check{name: "auth type", ok: true, msg: string(authType)})
 
-	opts := api.Options{ProjectID: profile.ProjectID, Version: cmd.Root().Version}
+	resolvedProject := cliutil.ResolveProjectID(cmd, profile)
+	opts := api.Options{ProjectID: resolvedProject, Version: cmd.Root().Version}
 	switch authType {
 	case authstore.AuthTypeOAuth:
 		if profile.AccessToken == "" {
@@ -81,20 +82,20 @@ func runAuthDoctor(cmd *cobra.Command, args []string) error {
 	} else {
 		checks = append(checks, check{name: "API reach", ok: true, msg: fmt.Sprintf("ok, %d project access", len(projects))})
 
-		if profile.ProjectID == "" {
-			checks = append(checks, check{name: "project binding", ok: false, msg: "no project_id stored on profile", hint: "rerun `revcat auth login` and pick a project"})
+		if resolvedProject == "" {
+			checks = append(checks, check{name: "project context", ok: false, msg: "no project_id resolved", hint: "run `revcat init` in your repo, pass --project-id, or set REVCAT_PROJECT_ID"})
 		} else {
 			found := false
 			for _, p := range projects {
-				if p.ID == profile.ProjectID {
+				if p.ID == resolvedProject {
 					found = true
 					break
 				}
 			}
 			if !found {
-				checks = append(checks, check{name: "project binding", ok: false, msg: profile.ProjectID + " not in this key's project list", hint: "the key may have been rotated to a different project; rerun `revcat auth login`"})
+				checks = append(checks, check{name: "project context", ok: false, msg: resolvedProject + " not accessible to this profile", hint: "the project may have been moved or your auth profile lacks access"})
 			} else {
-				checks = append(checks, check{name: "project binding", ok: true, msg: profile.ProjectID})
+				checks = append(checks, check{name: "project context", ok: true, msg: resolvedProject})
 			}
 		}
 	}

--- a/commands/auth/list.go
+++ b/commands/auth/list.go
@@ -34,7 +34,11 @@ func runList(cmd *cobra.Command, args []string) error {
 			rows = append(rows, []any{marker, n, "(unreadable)", ""})
 			continue
 		}
-		rows = append(rows, []any{marker, n, redactKey(p.SecretKey), emptyDash(p.ProjectID)})
+		credential := redactKey(p.SecretKey)
+		if p.EffectiveAuthType() == authstore.AuthTypeOAuth {
+			credential = "oauth:" + redactKey(p.AccessToken)
+		}
+		rows = append(rows, []any{marker, n, string(p.EffectiveAuthType()), credential, emptyDash(p.ProjectID)})
 	}
-	return output.Table([]string{"", "name", "secret_key", "project_id"}, rows)
+	return output.Table([]string{"", "name", "auth_type", "credential", "project_id"}, rows)
 }

--- a/commands/auth/login.go
+++ b/commands/auth/login.go
@@ -22,23 +22,33 @@ var (
 	loginSecretStdin bool
 	loginProjectID   string
 	loginNoVerify    bool
+	loginOAuth       bool
+	loginClientID    string
+	loginScopes      []string
 )
 
 var loginCmd = &cobra.Command{
 	Use:   "login",
-	Short: "Save a RevenueCat secret key as a named profile",
-	Long: `Save a RevenueCat v2 secret key (sk_...) as a named profile.
+	Short: "Save credentials as a named profile",
+	Long: `Save credentials as a named profile. Two auth modes are supported:
 
-Without flags this is interactive. With flags it's scriptable. The key is
-written to your OS keychain unless --bypass-keychain is set, in which case
-it's written to ./.revcat/config.json (a .gitignore is created on first use).
+(1) v2 secret key (default): pass --secret-key sk_..., pipe via
+    --secret-key-stdin, or be prompted. Stored in the OS keychain (or
+    ./.revcat/config.json with --bypass-keychain).
+
+(2) OAuth (PKCE): pass --oauth. revcat opens your browser, you authorize
+    against RevenueCat, and the access + refresh tokens are stored on
+    the profile. Uses the public revcat OAuth client by default;
+    override with REVCAT_OAUTH_CLIENT_ID or --client-id.
 
 Examples:
-  revcat auth login                                                   # interactive
+  revcat auth login                                                   # interactive secret-key
   echo $RC_KEY | revcat auth login --name prod --secret-key-stdin     # scripted, no shell history
-  revcat auth login --name prod --secret-key sk_xxx                   # scripted (key visible in history)
+  revcat auth login --name prod --secret-key sk_xxx                   # scripted (key in shell history)
   echo $RC_KEY | revcat auth login --name ci --secret-key-stdin \
-    --project-id proj_xxx --no-verify                                 # CI`,
+    --project-id proj_xxx --no-verify                                 # CI
+  revcat auth login --oauth --name my-app                             # OAuth in the browser
+  revcat auth login --oauth --client-id <id>                          # OAuth with explicit client_id`,
 	RunE: runLogin,
 }
 
@@ -47,12 +57,18 @@ func init() {
 	loginCmd.Flags().StringVarP(&loginSecretKey, "secret-key", "k", "", "RevenueCat v2 secret key (sk_...). Warning: visible in shell history; prefer --secret-key-stdin in production")
 	loginCmd.Flags().BoolVar(&loginSecretStdin, "secret-key-stdin", false, "Read the secret key from stdin (recommended for scripts/CI; avoids leaking the key into shell history)")
 	loginCmd.Flags().StringVar(&loginProjectID, "project-id", "", "Project id to bind (auto-detected from /v2/projects if omitted)")
-	loginCmd.Flags().BoolVar(&loginNoVerify, "no-verify", false, "Skip the API check that the key is valid")
+	loginCmd.Flags().BoolVar(&loginNoVerify, "no-verify", false, "Skip the API check that the credentials work")
+	loginCmd.Flags().BoolVar(&loginOAuth, "oauth", false, "Use the OAuth (PKCE) flow instead of a secret key")
+	loginCmd.Flags().StringVar(&loginClientID, "client-id", "", "OAuth client_id (defaults to REVCAT_OAUTH_CLIENT_ID env or the embedded public client)")
+	loginCmd.Flags().StringSliceVar(&loginScopes, "scope", nil, "OAuth scopes (default: revcat's full read/write set)")
 }
 
 func runLogin(cmd *cobra.Command, args []string) error {
 	if loginName == "" {
 		loginName = "default"
+	}
+	if loginOAuth {
+		return runOAuthLogin(cmd)
 	}
 	if loginSecretStdin && loginSecretKey != "" {
 		return fmt.Errorf("--secret-key and --secret-key-stdin are mutually exclusive; pass only one")

--- a/commands/auth/login_oauth.go
+++ b/commands/auth/login_oauth.go
@@ -88,7 +88,6 @@ func runOAuthLogin(cmd *cobra.Command) error {
 	profile := &authstore.Profile{
 		Name:         loginName,
 		AuthType:     authstore.AuthTypeOAuth,
-		ProjectID:    loginProjectID,
 		AccessToken:  tok.AccessToken,
 		RefreshToken: tok.RefreshToken,
 		ExpiresAt:    expiresAt,
@@ -99,21 +98,12 @@ func runOAuthLogin(cmd *cobra.Command) error {
 	if !loginNoVerify {
 		client := api.New(api.Options{
 			TokenSource: authstore.NewOAuthTokenSource(store, profile),
-			ProjectID:   profile.ProjectID,
 			Version:     cmd.Root().Version,
 		})
 		vctx, vcancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 		defer vcancel()
-		projects, err := client.ListProjects(vctx)
-		if err != nil {
+		if _, err := client.ListProjects(vctx); err != nil {
 			return fmt.Errorf("verify access: %w", err)
-		}
-		if profile.ProjectID == "" && len(projects) > 0 {
-			id, err := pickProject(projects)
-			if err != nil {
-				return err
-			}
-			profile.ProjectID = id
 		}
 	}
 
@@ -126,11 +116,9 @@ func runOAuthLogin(cmd *cobra.Command) error {
 		loc = "./.revcat/config.json"
 	}
 	output.Success("oauth login saved as %q in %s", loginName, loc)
-	if profile.ProjectID != "" {
-		output.Info("  project_id: %s", profile.ProjectID)
-	}
 	output.Info("  expires:    %s", time.UnixMilli(profile.ExpiresAt).Local().Format("2006-01-02 15:04 MST"))
 	output.Info("  scope:      %s", profile.Scope)
+	output.Info("next: cd into your repo and run `revcat init` to bind a project_id")
 	output.Info("  use it: revcat --profile %s ...", loginName)
 	return nil
 }

--- a/commands/auth/login_oauth.go
+++ b/commands/auth/login_oauth.go
@@ -1,0 +1,147 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/akshitkrnagpal/revcat/internal/api"
+	authstore "github.com/akshitkrnagpal/revcat/internal/auth"
+	"github.com/akshitkrnagpal/revcat/internal/output"
+)
+
+// runOAuthLogin drives the PKCE flow:
+//  1. resolve the client_id (flag > env > embedded)
+//  2. start a local callback server, generate PKCE
+//  3. open the browser to RC's authorize URL
+//  4. wait for the redirect, exchange the code, store tokens
+func runOAuthLogin(cmd *cobra.Command) error {
+	clientID := loginClientID
+	if clientID == "" {
+		clientID = authstore.OAuthClientID()
+	}
+	if clientID == "" {
+		return errors.New("no OAuth client_id configured. set REVCAT_OAUTH_CLIENT_ID or pass --client-id. RevenueCat must register revcat as a public OAuth client first; see https://www.revenuecat.com/docs/projects/oauth-setup")
+	}
+
+	scopes := loginScopes
+	if len(scopes) == 0 {
+		scopes = api.DefaultScopes
+	}
+
+	pkce, err := api.NewPKCE()
+	if err != nil {
+		return err
+	}
+
+	server, err := api.NewLoopbackServer()
+	if err != nil {
+		return err
+	}
+	defer server.Close()
+
+	state, err := randomStateOrFatal()
+	if err != nil {
+		return err
+	}
+
+	authURL := api.AuthorizeURL(clientID, server.URL, scopes, state, pkce.Challenge)
+
+	output.Info("opening browser to authorize revcat")
+	output.Info("if it doesn't open automatically, paste this URL:\n  %s", authURL)
+	if err := api.OpenBrowser(authURL); err != nil {
+		// non-fatal: user can copy/paste manually.
+		output.Warn("could not auto-open browser: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
+	defer cancel()
+	resp, err := server.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("waiting for callback: %w", err)
+	}
+	if resp.Err != "" {
+		return fmt.Errorf("authorization rejected (%s): %s", resp.Err, resp.ErrDesc)
+	}
+	if resp.State != state {
+		return errors.New("state mismatch on callback - possible CSRF; refusing to continue")
+	}
+
+	tok, err := api.ExchangeCode(ctx, clientID, "", resp.Code, server.URL, pkce.Verifier)
+	if err != nil {
+		return fmt.Errorf("token exchange: %w", err)
+	}
+
+	store, err := authstore.Open(bypassKeychain(cmd))
+	if err != nil {
+		return err
+	}
+
+	expiresAt := int64(0)
+	if tok.ExpiresIn > 0 {
+		expiresAt = time.Now().Add(time.Duration(tok.ExpiresIn) * time.Second).UnixMilli()
+	}
+
+	profile := &authstore.Profile{
+		Name:         loginName,
+		AuthType:     authstore.AuthTypeOAuth,
+		ProjectID:    loginProjectID,
+		AccessToken:  tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		ExpiresAt:    expiresAt,
+		Scope:        tok.Scope,
+		ClientID:     clientID,
+	}
+
+	if !loginNoVerify {
+		client := api.New(api.Options{
+			TokenSource: authstore.NewOAuthTokenSource(store, profile),
+			ProjectID:   profile.ProjectID,
+			Version:     cmd.Root().Version,
+		})
+		vctx, vcancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+		defer vcancel()
+		projects, err := client.ListProjects(vctx)
+		if err != nil {
+			return fmt.Errorf("verify access: %w", err)
+		}
+		if profile.ProjectID == "" && len(projects) > 0 {
+			id, err := pickProject(projects)
+			if err != nil {
+				return err
+			}
+			profile.ProjectID = id
+		}
+	}
+
+	if err := store.Set(profile); err != nil {
+		return err
+	}
+
+	loc := "OS keychain"
+	if bypassKeychain(cmd) {
+		loc = "./.revcat/config.json"
+	}
+	output.Success("oauth login saved as %q in %s", loginName, loc)
+	if profile.ProjectID != "" {
+		output.Info("  project_id: %s", profile.ProjectID)
+	}
+	output.Info("  expires:    %s", time.UnixMilli(profile.ExpiresAt).Local().Format("2006-01-02 15:04 MST"))
+	output.Info("  scope:      %s", profile.Scope)
+	output.Info("  use it: revcat --profile %s ...", loginName)
+	return nil
+}
+
+// randomStateOrFatal wraps the api.randomState helper - the real impl
+// lives in the api package so api/oauth_test can exercise it.
+func randomStateOrFatal() (string, error) {
+	// borrow the same generator the api package uses for PKCE.
+	p, err := api.NewPKCE()
+	if err != nil {
+		return "", err
+	}
+	return p.Verifier, nil
+}

--- a/commands/auth/login_oauth.go
+++ b/commands/auth/login_oauth.go
@@ -24,7 +24,7 @@ func runOAuthLogin(cmd *cobra.Command) error {
 		clientID = authstore.OAuthClientID()
 	}
 	if clientID == "" {
-		return errors.New("no OAuth client_id configured. set REVCAT_OAUTH_CLIENT_ID or pass --client-id. RevenueCat must register revcat as a public OAuth client first; see https://www.revenuecat.com/docs/projects/oauth-setup")
+		return errors.New("no OAuth client_id configured. set REVCAT_OAUTH_CLIENT_ID, pass --client-id, or build with -ldflags '-X .../auth.EmbeddedClientID=<id>'")
 	}
 
 	scopes := loginScopes
@@ -43,7 +43,7 @@ func runOAuthLogin(cmd *cobra.Command) error {
 	}
 	defer server.Close()
 
-	state, err := randomStateOrFatal()
+	state, err := api.RandomState()
 	if err != nil {
 		return err
 	}
@@ -135,13 +135,3 @@ func runOAuthLogin(cmd *cobra.Command) error {
 	return nil
 }
 
-// randomStateOrFatal wraps the api.randomState helper - the real impl
-// lives in the api package so api/oauth_test can exercise it.
-func randomStateOrFatal() (string, error) {
-	// borrow the same generator the api package uses for PKCE.
-	p, err := api.NewPKCE()
-	if err != nil {
-		return "", err
-	}
-	return p.Verifier, nil
-}

--- a/commands/auth/status.go
+++ b/commands/auth/status.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/akshitkrnagpal/revcat/internal/api"
 	authstore "github.com/akshitkrnagpal/revcat/internal/auth"
+	"github.com/akshitkrnagpal/revcat/internal/cliutil"
 	"github.com/akshitkrnagpal/revcat/internal/output"
 )
 
@@ -35,7 +36,11 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	profile, err := authstore.Resolve(store, statusName)
+	name := statusName
+	if name == "" {
+		name = cliutil.Profile(cmd)
+	}
+	profile, err := authstore.Resolve(store, name)
 	if err != nil {
 		return err
 	}

--- a/commands/auth/status.go
+++ b/commands/auth/status.go
@@ -51,12 +51,27 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	rows := [][]any{
 		{"profile", profile.Name},
 		{"source", source},
-		{"secret_key", redactKey(profile.SecretKey)},
-		{"project_id", emptyDash(profile.ProjectID)},
+		{"auth_type", string(profile.EffectiveAuthType())},
 	}
+	if profile.EffectiveAuthType() == authstore.AuthTypeOAuth {
+		rows = append(rows,
+			[]any{"access_token", redactKey(profile.AccessToken)},
+			[]any{"expires", expiresLine(profile.ExpiresAt)},
+			[]any{"scope", emptyDash(profile.Scope)},
+		)
+	} else {
+		rows = append(rows, []any{"secret_key", redactKey(profile.SecretKey)})
+	}
+	rows = append(rows, []any{"project_id", emptyDash(profile.ProjectID)})
 
 	if statusValidate {
-		client := api.New(api.Options{SecretKey: profile.SecretKey, ProjectID: profile.ProjectID, Version: cmd.Root().Version})
+		opts := api.Options{ProjectID: profile.ProjectID, Version: cmd.Root().Version}
+		if profile.EffectiveAuthType() == authstore.AuthTypeOAuth {
+			opts.TokenSource = authstore.NewOAuthTokenSource(store, profile)
+		} else {
+			opts.SecretKey = profile.SecretKey
+		}
+		client := api.New(opts)
 		ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 		defer cancel()
 		projects, err := client.ListProjects(ctx)
@@ -71,6 +86,18 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	return output.Table([]string{"field", "value"}, rows)
+}
+
+func expiresLine(ms int64) string {
+	if ms == 0 {
+		return "-"
+	}
+	t := time.UnixMilli(ms).Local()
+	delta := time.Until(t)
+	if delta < 0 {
+		return t.Format("2006-01-02 15:04 MST") + " (EXPIRED)"
+	}
+	return t.Format("2006-01-02 15:04 MST")
 }
 
 func emptyDash(s string) string {

--- a/commands/auth/status.go
+++ b/commands/auth/status.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -11,6 +12,7 @@ import (
 	authstore "github.com/akshitkrnagpal/revcat/internal/auth"
 	"github.com/akshitkrnagpal/revcat/internal/cliutil"
 	"github.com/akshitkrnagpal/revcat/internal/output"
+	"github.com/akshitkrnagpal/revcat/internal/project"
 )
 
 var (
@@ -67,10 +69,12 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	} else {
 		rows = append(rows, []any{"secret_key", redactKey(profile.SecretKey)})
 	}
-	rows = append(rows, []any{"project_id", emptyDash(profile.ProjectID)})
+	resolvedProject := cliutil.ResolveProjectID(cmd, profile)
+	rows = append(rows, []any{"project_id", emptyDash(resolvedProject)})
+	rows = append(rows, []any{"project_source", projectSource(cmd, profile)})
 
 	if statusValidate {
-		opts := api.Options{ProjectID: profile.ProjectID, Version: cmd.Root().Version}
+		opts := api.Options{ProjectID: resolvedProject, Version: cmd.Root().Version}
 		if profile.EffectiveAuthType() == authstore.AuthTypeOAuth {
 			opts.TokenSource = authstore.NewOAuthTokenSource(store, profile)
 		} else {
@@ -91,6 +95,24 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	return output.Table([]string{"field", "value"}, rows)
+}
+
+// projectSource explains where the resolved project_id came from so the
+// user can debug "why am I hitting the wrong project?".
+func projectSource(cmd *cobra.Command, p *authstore.Profile) string {
+	if v := cliutil.ProjectIDFlag(cmd); v != "" {
+		return "--project-id flag"
+	}
+	if v := os.Getenv("REVCAT_PROJECT_ID"); v != "" {
+		return "REVCAT_PROJECT_ID env"
+	}
+	if cfg, err := project.LoadFromCwd(); err == nil && cfg.ProjectID != "" {
+		return cfg.Path
+	}
+	if p != nil && p.ProjectID != "" {
+		return "profile binding"
+	}
+	return "-"
 }
 
 func expiresLine(ms int64) string {

--- a/commands/doctor/doctor.go
+++ b/commands/doctor/doctor.go
@@ -13,8 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/akshitkrnagpal/revcat/internal/api"
-	authstore "github.com/akshitkrnagpal/revcat/internal/auth"
+	"github.com/akshitkrnagpal/revcat/internal/cliutil"
 	"github.com/akshitkrnagpal/revcat/internal/output"
 )
 
@@ -26,35 +25,24 @@ var Cmd = &cobra.Command{
 }
 
 func runDoctor(cmd *cobra.Command, args []string) error {
-	bypass := false
-	if f := cmd.Root().PersistentFlags().Lookup("bypass-keychain"); f != nil {
-		bypass = f.Value.String() == "true"
-	}
-
 	rows := [][]any{
 		{"OK", "platform", fmt.Sprintf("%s/%s %s", runtime.GOOS, runtime.GOARCH, runtime.Version())},
 		{"OK", "revcat", cmd.Root().Version},
 	}
 
-	store, err := authstore.Open(bypass)
-	if err != nil {
-		rows = append(rows, []any{"FAIL", "credential store", err.Error()})
-		return output.Table([]string{"status", "check", "detail"}, rows)
-	}
 	storeName := "keychain"
-	if bypass {
+	if cliutil.BypassKeychain(cmd) {
 		storeName = "local file"
 	}
-	rows = append(rows, []any{"OK", "credential store", storeName})
 
-	profile, err := authstore.Resolve(store, "")
+	client, profile, err := cliutil.Client(cmd)
 	if err != nil {
-		rows = append(rows, []any{"FAIL", "active profile", "no profile found - run `revcat auth login`"})
+		rows = append(rows, []any{"FAIL", "credential store / active profile", err.Error()})
 		return output.Table([]string{"status", "check", "detail"}, rows)
 	}
-	rows = append(rows, []any{"OK", "active profile", profile.Name})
+	rows = append(rows, []any{"OK", "credential store", storeName})
+	rows = append(rows, []any{"OK", "active profile", fmt.Sprintf("%s (%s)", profile.Name, profile.EffectiveAuthType())})
 
-	client := api.New(api.Options{SecretKey: profile.SecretKey, ProjectID: profile.ProjectID, Version: cmd.Root().Version})
 	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 	defer cancel()
 	projects, err := client.ListProjects(ctx)
@@ -63,6 +51,12 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		return output.Table([]string{"status", "check", "detail"}, rows)
 	}
 	rows = append(rows, []any{"OK", "api reach", fmt.Sprintf("ok, %d project access", len(projects))})
+
+	if pid := cliutil.ResolveProjectID(cmd, profile); pid != "" {
+		rows = append(rows, []any{"OK", "project context", pid})
+	} else {
+		rows = append(rows, []any{"WARN", "project context", "none - run `revcat init` or pass --project-id"})
+	}
 
 	return output.Table([]string{"status", "check", "detail"}, rows)
 }

--- a/commands/initcmd/init.go
+++ b/commands/initcmd/init.go
@@ -1,0 +1,201 @@
+// Package initcmd implements `revcat init` - the per-repo project
+// context bootstrap. Writes a revcat.toml at the cwd that pins the
+// project_id so subsequent commands run in the right RC project without
+// the user having to remember.
+package initcmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/akshitkrnagpal/revcat/internal/api"
+	"github.com/akshitkrnagpal/revcat/internal/cliutil"
+	"github.com/akshitkrnagpal/revcat/internal/output"
+	"github.com/akshitkrnagpal/revcat/internal/project"
+)
+
+var (
+	flagAppIDs []string
+	flagForce  bool
+	flagPath   string
+	flagNoApps bool
+)
+
+// Cmd is the cobra command exported to the root.
+var Cmd = &cobra.Command{
+	Use:   "init",
+	Short: "Bootstrap revcat.toml in the current directory",
+	Long: `Write a revcat.toml at the current directory pinning the project_id
+(and optional apps). Once present, every command run from this repo
+inherits the binding without --project-id.
+
+Interactive (default): lists projects you can access, prompts for one,
+then optionally lists apps in that project and lets you tag them.
+
+Scripted: pass --project-id (and optional --app-id, repeated). Skip the
+apps block entirely with --no-apps.`,
+	RunE: runInit,
+}
+
+func init() {
+	Cmd.Flags().StringSliceVar(&flagAppIDs, "app-id", nil, "App ids to record (repeatable)")
+	Cmd.Flags().BoolVar(&flagForce, "force", false, "Overwrite an existing revcat.toml")
+	Cmd.Flags().StringVar(&flagPath, "path", "", "Where to write revcat.toml (default: cwd)")
+	Cmd.Flags().BoolVar(&flagNoApps, "no-apps", false, "Skip the apps section entirely")
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	dir := flagPath
+	if dir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		dir = cwd
+	}
+	target := filepath.Join(dir, project.FileName)
+
+	if _, err := os.Stat(target); err == nil && !flagForce {
+		return fmt.Errorf("%s already exists; pass --force to overwrite", target)
+	}
+
+	client, _, err := cliutil.Client(cmd)
+	if err != nil {
+		return err
+	}
+
+	projectID, err := pickProjectID(cmd.Context(), cmd, client)
+	if err != nil {
+		return err
+	}
+
+	cfg := &project.Config{ProjectID: projectID}
+
+	if !flagNoApps {
+		apps, err := pickApps(cmd.Context(), cmd, projectID)
+		if err != nil {
+			return err
+		}
+		cfg.Apps = apps
+	}
+
+	if err := project.Save(target, cfg); err != nil {
+		return fmt.Errorf("write %s: %w", target, err)
+	}
+
+	output.Success("wrote %s", target)
+	output.Info("  project_id: %s", cfg.ProjectID)
+	if len(cfg.Apps) > 0 {
+		ids := make([]string, len(cfg.Apps))
+		for i, a := range cfg.Apps {
+			ids[i] = a.ID
+		}
+		output.Info("  apps:       %s", strings.Join(ids, ", "))
+	}
+	output.Info("commit revcat.toml so collaborators get the same context")
+	return nil
+}
+
+func pickProjectID(parent context.Context, cmd *cobra.Command, client *api.Client) (string, error) {
+	if v := cliutil.ProjectIDFlag(cmd); v != "" {
+		return v, nil
+	}
+	if v := os.Getenv("REVCAT_PROJECT_ID"); v != "" {
+		return v, nil
+	}
+	ctx, cancel := context.WithTimeout(parent, 10*time.Second)
+	defer cancel()
+	projects, err := client.ListProjects(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list projects: %w", err)
+	}
+	if len(projects) == 0 {
+		return "", errors.New("no project access on this profile")
+	}
+	if len(projects) == 1 {
+		output.Info("only one accessible project: %s (%s)", projects[0].Name, projects[0].ID)
+		return projects[0].ID, nil
+	}
+	options := make([]string, len(projects))
+	for i, p := range projects {
+		options[i] = fmt.Sprintf("%s (%s)", p.Name, p.ID)
+	}
+	var idx int
+	if err := survey.AskOne(&survey.Select{
+		Message: "Which project?",
+		Options: options,
+	}, &idx); err != nil {
+		return "", err
+	}
+	return projects[idx].ID, nil
+}
+
+func pickApps(parent context.Context, cmd *cobra.Command, projectID string) ([]project.App, error) {
+	if len(flagAppIDs) > 0 {
+		out := make([]project.App, len(flagAppIDs))
+		for i, id := range flagAppIDs {
+			out[i] = project.App{ID: id}
+		}
+		return out, nil
+	}
+	// Re-bind the API client to the chosen project_id so /projects/{id}/apps
+	// hits the right path (the caller's client may have no project bound
+	// yet — there's no revcat.toml yet to resolve from).
+	scoped, _, err := cliutil.ClientForProject(cmd, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(parent, 10*time.Second)
+	defer cancel()
+	apps, err := scoped.ListApps(ctx)
+	if err != nil {
+		// Don't block init on app listing failure - the file is still
+		// useful with project_id alone.
+		output.Warn("could not list apps (%v); writing project_id only", err)
+		return nil, nil
+	}
+	if len(apps) == 0 {
+		return nil, nil
+	}
+	options := make([]string, len(apps))
+	for i, a := range apps {
+		bundle := a.BundleID
+		if bundle == "" {
+			bundle = a.PackageName
+		}
+		if bundle != "" {
+			options[i] = fmt.Sprintf("%s · %s · %s (%s)", a.Name, a.Type, bundle, a.ID)
+		} else {
+			options[i] = fmt.Sprintf("%s · %s (%s)", a.Name, a.Type, a.ID)
+		}
+	}
+	defaults := make([]string, 0, len(options))
+	for _, o := range options {
+		defaults = append(defaults, o)
+	}
+	var picked []int
+	if err := survey.AskOne(&survey.MultiSelect{
+		Message: "Which apps to record? (space to toggle, enter to confirm; leave empty to skip)",
+		Options: options,
+		Default: defaults,
+	}, &picked); err != nil {
+		return nil, err
+	}
+	if len(picked) == 0 {
+		return nil, nil
+	}
+	out := make([]project.App, 0, len(picked))
+	for _, i := range picked {
+		out = append(out, project.App{ID: apps[i].ID, Name: apps[i].Name})
+	}
+	return out, nil
+}

--- a/commands/projects/projects.go
+++ b/commands/projects/projects.go
@@ -61,7 +61,7 @@ var viewCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		id := prof.ProjectID
+		id := cliutil.ResolveProjectID(cmd, prof)
 		if len(args) == 1 {
 			id = args[0]
 		}

--- a/commands/root.go
+++ b/commands/root.go
@@ -9,6 +9,7 @@ import (
 	authcmd "github.com/akshitkrnagpal/revcat/commands/auth"
 	doctorcmd "github.com/akshitkrnagpal/revcat/commands/doctor"
 	entitlementscmd "github.com/akshitkrnagpal/revcat/commands/entitlements"
+	initcmd "github.com/akshitkrnagpal/revcat/commands/initcmd"
 	invoicescmd "github.com/akshitkrnagpal/revcat/commands/invoices"
 	metricscmd "github.com/akshitkrnagpal/revcat/commands/metrics"
 	offeringscmd "github.com/akshitkrnagpal/revcat/commands/offerings"
@@ -39,6 +40,7 @@ type globalFlags struct {
 	Output         string
 	Pretty         bool
 	Profile        string
+	ProjectID      string
 	BypassKeychain bool
 }
 
@@ -81,6 +83,7 @@ func init() {
 	pf.StringVar(&Flags.Output, "output", "", "Output format: table | json | csv | markdown (auto-detect when empty)")
 	pf.BoolVar(&Flags.Pretty, "pretty", false, "Pretty-print JSON output")
 	pf.StringVar(&Flags.Profile, "profile", "", "Auth profile name (default: REVCAT_PROFILE or 'default')")
+	pf.StringVar(&Flags.ProjectID, "project-id", "", "RevenueCat project id (default: REVCAT_PROJECT_ID, ./revcat.toml, or the bound profile)")
 	pf.BoolVar(&Flags.BypassKeychain, "bypass-keychain", false, "Read/write auth from ./.revcat/config.json instead of OS keychain")
 
 	rootCmd.AddCommand(appscmd.Cmd)
@@ -88,6 +91,7 @@ func init() {
 	rootCmd.AddCommand(authcmd.Cmd)
 	rootCmd.AddCommand(doctorcmd.Cmd)
 	rootCmd.AddCommand(entitlementscmd.Cmd)
+	rootCmd.AddCommand(initcmd.Cmd)
 	rootCmd.AddCommand(invoicescmd.Cmd)
 	rootCmd.AddCommand(metricscmd.Cmd)
 	rootCmd.AddCommand(metricscmd.ChartsCmd)

--- a/commands/subscribers/info.go
+++ b/commands/subscribers/info.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/akshitkrnagpal/revcat/internal/api"
-	authstore "github.com/akshitkrnagpal/revcat/internal/auth"
+	"github.com/akshitkrnagpal/revcat/internal/cliutil"
 	"github.com/akshitkrnagpal/revcat/internal/output"
 )
 
@@ -34,20 +34,10 @@ Example:
 func runInfo(cmd *cobra.Command, args []string) error {
 	customerID := args[0]
 
-	store, err := authstore.Open(bypassKeychain(cmd))
+	client, _, err := cliutil.Client(cmd)
 	if err != nil {
 		return err
 	}
-	prof, err := authstore.Resolve(store, profile(cmd))
-	if err != nil {
-		return err
-	}
-
-	client := api.New(api.Options{
-		SecretKey: prof.SecretKey,
-		ProjectID: prof.ProjectID,
-		Version:   cmd.Root().Version,
-	})
 
 	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 	defer cancel()

--- a/commands/subscribers/subscribers.go
+++ b/commands/subscribers/subscribers.go
@@ -16,21 +16,3 @@ entitlements, subscriptions, purchases, and aliases in a single card.`,
 func init() {
 	Cmd.AddCommand(infoCmd)
 }
-
-// bypassKeychain reads the global flag from the cobra root.
-func bypassKeychain(cmd *cobra.Command) bool {
-	flag := cmd.Root().PersistentFlags().Lookup("bypass-keychain")
-	if flag == nil {
-		return false
-	}
-	return flag.Value.String() == "true"
-}
-
-// profile reads the global --profile flag.
-func profile(cmd *cobra.Command) string {
-	flag := cmd.Root().PersistentFlags().Lookup("profile")
-	if flag == nil {
-		return ""
-	}
-	return flag.Value.String()
-}

--- a/docs/src/content/docs/commands/auth.md
+++ b/docs/src/content/docs/commands/auth.md
@@ -11,18 +11,31 @@ For CI, pass `--bypass-keychain` (or set `REVCAT_BYPASS_KEYCHAIN=1`) to use a lo
 
 | Command | Description |
 | --- | --- |
-| `auth login` | Save a RevenueCat secret key as a named profile |
+| `auth login` | Save credentials as a named profile (secret key or OAuth) |
 | `auth status` | Show the active auth profile (`--validate` hits the API) |
 | `auth doctor` | Self-diagnose auth setup |
 | `auth use <name>` | Set the default auth profile |
 | `auth list` | List stored auth profiles |
 | `auth logout [name]` | Remove a stored auth profile (`--all` wipes them all) |
 
+## Auth modes
+
+revcat supports two credential models, both stored in the OS keychain:
+
+1. **v2 secret key** (default). Pass `--secret-key sk_...`. Simple and scriptable.
+2. **OAuth (PKCE)**. Pass `--oauth`. revcat opens your browser, you authorize against RevenueCat, the access + refresh tokens land on the profile. Tokens auto-refresh on each command. Requires a registered OAuth `client_id` (set `REVCAT_OAUTH_CLIENT_ID` or pass `--client-id`).
+
 ## Examples
 
 ```sh
+# secret key
 revcat auth login --name my-app --secret-key sk_xxx
 revcat auth login --name my-app --secret-key sk_xxx --project-id proj_xxx --no-verify   # CI
+
+# oauth (requires a registered client_id)
+revcat auth login --oauth --name my-app
+REVCAT_OAUTH_CLIENT_ID=<id> revcat auth login --oauth --name my-app
+
 revcat auth status --validate
 revcat auth doctor
 revcat auth use my-app

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/99designs/keyring v1.2.2 h1:pZd3neh/EmUzWONb35LxQfvuY7kiSXAq3HQd97+XB
 github.com/99designs/keyring v1.2.2/go.mod h1:wes/FrByc8j7lFOAGLGSNEg8f/PaI3cgTBqhFkHUrPk=
 github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkkhIiSjQ=
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -147,7 +147,7 @@ func (c *Client) doRaw(ctx context.Context, method, path string, body any, out a
 		}
 		token, err := c.tokenSrc.Token(ctx)
 		if err != nil {
-			return fmt.Errorf("auth: %w", err)
+			return nil, fmt.Errorf("auth: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+token)
 		req.Header.Set("Accept", "application/json")

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -25,11 +25,29 @@ const userAgent = "revcat-cli"
 // envDebug toggles full request/response logging (key redacted).
 const envDebug = "REVCAT_DEBUG"
 
+// TokenSource hands out a current bearer token. Used to plug in either a
+// static secret key or an OAuth flow that auto-refreshes. token() is
+// called before each request, so an OAuth implementation can do a
+// refresh round-trip on the fly without the caller knowing.
+type TokenSource interface {
+	Token(ctx context.Context) (string, error)
+}
+
+// staticToken is the trivial source for project secret keys.
+type staticToken string
+
+func (s staticToken) Token(_ context.Context) (string, error) {
+	if s == "" {
+		return "", errors.New("no auth token configured")
+	}
+	return string(s), nil
+}
+
 // Client talks to the RC v2 REST API on behalf of a single profile.
 type Client struct {
 	http      *http.Client
 	baseURL   string
-	secretKey string
+	tokenSrc  TokenSource
 	projectID string
 	debug     bool
 	version   string
@@ -37,11 +55,15 @@ type Client struct {
 
 // New constructs a Client. SecretKey is required; ProjectID may be empty
 // for endpoints that don't need it (auth checks, project listing).
+//
+// Pass TokenSource for OAuth profiles where the access token rotates;
+// otherwise pass SecretKey and revcat builds a static source.
 type Options struct {
-	SecretKey string
-	ProjectID string
-	BaseURL   string
-	Version   string
+	SecretKey   string
+	TokenSource TokenSource
+	ProjectID   string
+	BaseURL     string
+	Version     string
 }
 
 func New(opts Options) *Client {
@@ -49,10 +71,14 @@ func New(opts Options) *Client {
 	if base == "" {
 		base = BaseURL
 	}
+	src := opts.TokenSource
+	if src == nil {
+		src = staticToken(opts.SecretKey)
+	}
 	return &Client{
 		http:      &http.Client{Timeout: 30 * time.Second},
 		baseURL:   base,
-		secretKey: opts.SecretKey,
+		tokenSrc:  src,
 		projectID: opts.ProjectID,
 		debug:     strings.Contains(os.Getenv(envDebug), "api"),
 		version:   opts.Version,
@@ -119,7 +145,11 @@ func (c *Client) doRaw(ctx context.Context, method, path string, body any, out a
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Set("Authorization", "Bearer "+c.secretKey)
+		token, err := c.tokenSrc.Token(ctx)
+		if err != nil {
+			return fmt.Errorf("auth: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("User-Agent", userAgent+"/"+c.version)
 		if body != nil {

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -22,10 +22,21 @@ import (
 //
 //	GET https://api.revenuecat.com/oauth2/authorize
 //	POST https://api.revenuecat.com/oauth2/token
-const (
+//
+// Vars (not consts) so tests can point at httptest servers via
+// overrideTokenURL.
+var (
 	OAuthAuthorizeURL = "https://api.revenuecat.com/oauth2/authorize"
 	OAuthTokenURL     = "https://api.revenuecat.com/oauth2/token"
 )
+
+// overrideTokenURL swaps the OAuth token endpoint and returns a restore
+// function. Test helper - not used by production code.
+func overrideTokenURL(u string) func() {
+	prev := OAuthTokenURL
+	OAuthTokenURL = u
+	return func() { OAuthTokenURL = prev }
+}
 
 // DefaultScopes is the set we ask for on `revcat auth login --oauth`.
 // Tracks what the CLI actually exercises today, plus project bootstrap.
@@ -77,9 +88,9 @@ func NewPKCE() (*PKCEPair, error) {
 	}, nil
 }
 
-// randomState returns a hex-encoded random string for the OAuth `state`
-// parameter (CSRF protection).
-func randomState() (string, error) {
+// RandomState returns a base64url-encoded random string suitable for the
+// OAuth `state` parameter (CSRF guard for the redirect).
+func RandomState() (string, error) {
 	buf := make([]byte, 16)
 	if _, err := rand.Read(buf); err != nil {
 		return "", err

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -1,0 +1,253 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// OAuth endpoints. RC v2 OAuth doc:
+//
+//	GET https://api.revenuecat.com/oauth2/authorize
+//	POST https://api.revenuecat.com/oauth2/token
+const (
+	OAuthAuthorizeURL = "https://api.revenuecat.com/oauth2/authorize"
+	OAuthTokenURL     = "https://api.revenuecat.com/oauth2/token"
+)
+
+// DefaultScopes is the set we ask for on `revcat auth login --oauth`.
+// Tracks what the CLI actually exercises today, plus project bootstrap.
+var DefaultScopes = []string{
+	"project_configuration:projects:read_write",
+	"project_configuration:apps:read_write",
+	"project_configuration:entitlements:read_write",
+	"project_configuration:offerings:read_write",
+	"project_configuration:packages:read_write",
+	"project_configuration:products:read_write",
+	"project_configuration:integrations:read_write",
+	"project_configuration:virtual_currencies:read_write",
+	"customer_information:customers:read_write",
+	"customer_information:subscriptions:read_write",
+	"customer_information:purchases:read_write",
+	"customer_information:invoices:read",
+	"charts_metrics:overview:read",
+	"charts_metrics:charts:read",
+}
+
+// TokenResponse mirrors RC's OAuth token endpoint payload.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+}
+
+// PKCEPair is one round of code_verifier + code_challenge used by the
+// PKCE flow. Generated fresh per login.
+type PKCEPair struct {
+	Verifier  string
+	Challenge string
+}
+
+// NewPKCE generates a fresh verifier (43-128 url-safe chars per RFC 7636)
+// and the corresponding S256 challenge.
+func NewPKCE() (*PKCEPair, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return nil, err
+	}
+	verifier := base64.RawURLEncoding.EncodeToString(buf)
+	sum := sha256.Sum256([]byte(verifier))
+	return &PKCEPair{
+		Verifier:  verifier,
+		Challenge: base64.RawURLEncoding.EncodeToString(sum[:]),
+	}, nil
+}
+
+// randomState returns a hex-encoded random string for the OAuth `state`
+// parameter (CSRF protection).
+func randomState() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// AuthorizeURL builds the URL the user opens in the browser.
+func AuthorizeURL(clientID, redirectURI string, scopes []string, state, codeChallenge string) string {
+	q := url.Values{}
+	q.Set("client_id", clientID)
+	q.Set("response_type", "code")
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", strings.Join(scopes, " "))
+	q.Set("code_challenge", codeChallenge)
+	q.Set("code_challenge_method", "S256")
+	if state != "" {
+		q.Set("state", state)
+	}
+	return OAuthAuthorizeURL + "?" + q.Encode()
+}
+
+// LoopbackServer waits for the OAuth callback on localhost. RC redirects
+// the browser to http://127.0.0.1:<port>/callback?code=...&state=... and
+// we capture the code. Cancellation via ctx.
+type LoopbackServer struct {
+	Port  int
+	URL   string // full redirect URI registered with RC
+	addr  net.Addr
+	srv   *http.Server
+	done  chan struct{}
+	got   *AuthorizationResponse
+}
+
+// AuthorizationResponse is the result of the redirect, parsed.
+type AuthorizationResponse struct {
+	Code  string
+	State string
+	Err   string // populated when RC redirects with ?error=...
+	ErrDesc string
+}
+
+// NewLoopbackServer binds 127.0.0.1 on a free port and serves /callback.
+// Caller must Close() the server when done.
+func NewLoopbackServer() (*LoopbackServer, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("bind callback port: %w", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	ls := &LoopbackServer{
+		Port: port,
+		URL:  fmt.Sprintf("http://127.0.0.1:%d/callback", port),
+		addr: listener.Addr(),
+		done: make(chan struct{}),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		ls.got = &AuthorizationResponse{
+			Code:    q.Get("code"),
+			State:   q.Get("state"),
+			Err:     q.Get("error"),
+			ErrDesc: q.Get("error_description"),
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if ls.got.Err != "" {
+			fmt.Fprintf(w, callbackHTML, "Authorization failed", ls.got.Err+": "+ls.got.ErrDesc)
+		} else {
+			fmt.Fprintf(w, callbackHTML, "You're signed in", "You can close this tab and return to the terminal.")
+		}
+		go func() { close(ls.done) }()
+	})
+	ls.srv = &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = ls.srv.Serve(listener) }()
+	return ls, nil
+}
+
+// Wait blocks until the redirect arrives or ctx is cancelled.
+func (ls *LoopbackServer) Wait(ctx context.Context) (*AuthorizationResponse, error) {
+	select {
+	case <-ls.done:
+		return ls.got, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// Close stops the HTTP server.
+func (ls *LoopbackServer) Close() {
+	_ = ls.srv.Shutdown(context.Background())
+}
+
+// callbackHTML is rendered to the browser tab after the redirect.
+const callbackHTML = `<!doctype html>
+<html><head><title>revcat auth</title>
+<style>
+body { font: 16px system-ui, sans-serif; max-width: 480px; margin: 80px auto; padding: 0 24px; color: #1a1a1a; }
+h1 { font-size: 22px; margin-bottom: 12px; }
+p { color: #555; line-height: 1.5; }
+</style></head><body><h1>%s</h1><p>%s</p></body></html>`
+
+// OpenBrowser tries to open the URL in the user's default browser. Best-
+// effort - if it fails, the caller should still print the URL so the
+// user can copy it manually.
+func OpenBrowser(target string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", target)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
+	default:
+		cmd = exec.Command("xdg-open", target)
+	}
+	return cmd.Start()
+}
+
+// ExchangeCode swaps an authorization code (+ PKCE verifier) for tokens.
+// clientSecret is empty for public clients.
+func ExchangeCode(ctx context.Context, clientID, clientSecret, code, redirectURI, codeVerifier string) (*TokenResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", clientID)
+	form.Set("code_verifier", codeVerifier)
+	if clientSecret != "" {
+		form.Set("client_secret", clientSecret)
+	}
+	return postToken(ctx, form)
+}
+
+// RefreshToken trades a refresh_token for a new access_token (+ usually
+// a new refresh_token).
+func RefreshToken(ctx context.Context, clientID, clientSecret, refreshToken string) (*TokenResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	form.Set("client_id", clientID)
+	if clientSecret != "" {
+		form.Set("client_secret", clientSecret)
+	}
+	return postToken(ctx, form)
+}
+
+func postToken(ctx context.Context, form url.Values) (*TokenResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, "POST", OAuthTokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("oauth token endpoint %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out TokenResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("decode token response: %w", err)
+	}
+	if out.AccessToken == "" {
+		return nil, errors.New("oauth token response missing access_token")
+	}
+	return &out, nil
+}

--- a/internal/api/oauth_test.go
+++ b/internal/api/oauth_test.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewPKCE_S256ChallengeMatchesVerifier(t *testing.T) {
+	p, err := NewPKCE()
+	if err != nil {
+		t.Fatalf("NewPKCE: %v", err)
+	}
+	if len(p.Verifier) < 43 || len(p.Verifier) > 128 {
+		t.Fatalf("verifier length %d out of RFC 7636 range [43,128]", len(p.Verifier))
+	}
+	sum := sha256.Sum256([]byte(p.Verifier))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	if p.Challenge != want {
+		t.Fatalf("challenge does not match SHA-256(verifier): got %q want %q", p.Challenge, want)
+	}
+}
+
+func TestNewPKCE_VerifierIsRandom(t *testing.T) {
+	a, _ := NewPKCE()
+	b, _ := NewPKCE()
+	if a.Verifier == b.Verifier {
+		t.Fatalf("two PKCE pairs have the same verifier; rand source broken")
+	}
+}
+
+func TestAuthorizeURL_IncludesPKCEAndState(t *testing.T) {
+	got := AuthorizeURL("client_x", "http://127.0.0.1:1234/callback",
+		[]string{"a:read", "b:read_write"}, "state_xyz", "challenge_xyz")
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	q := u.Query()
+	for k, want := range map[string]string{
+		"response_type":         "code",
+		"client_id":             "client_x",
+		"redirect_uri":          "http://127.0.0.1:1234/callback",
+		"state":                 "state_xyz",
+		"code_challenge":        "challenge_xyz",
+		"code_challenge_method": "S256",
+		"scope":                 "a:read b:read_write",
+	} {
+		if got := q.Get(k); got != want {
+			t.Errorf("%s: got %q want %q", k, got, want)
+		}
+	}
+}
+
+func TestExchangeCode_PostsFormAndReturnsTokens(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method: got %s want POST", r.Method)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+			t.Errorf("Content-Type: %q", got)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		for k, want := range map[string]string{
+			"grant_type":    "authorization_code",
+			"code":          "code_abc",
+			"redirect_uri":  "http://127.0.0.1:1/callback",
+			"client_id":     "client_x",
+			"code_verifier": "verifier_xyz",
+		} {
+			if got := r.PostForm.Get(k); got != want {
+				t.Errorf("form[%s]: got %q want %q", k, got, want)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"access_token": "atk_new",
+			"token_type": "Bearer",
+			"expires_in": 3600,
+			"refresh_token": "rtk_new",
+			"scope": "a b"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("REVCAT_OAUTH_TOKEN_URL", "") // unused, but documents intent
+	prev := overrideTokenURL(srv.URL)
+	defer prev()
+
+	tok, err := ExchangeCode(context.Background(), "client_x", "", "code_abc",
+		"http://127.0.0.1:1/callback", "verifier_xyz")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if tok.AccessToken != "atk_new" || tok.RefreshToken != "rtk_new" {
+		t.Fatalf("tokens: %+v", tok)
+	}
+	if tok.ExpiresIn != 3600 {
+		t.Fatalf("expires_in: %d", tok.ExpiresIn)
+	}
+}
+
+func TestRefreshToken_PostsRefreshGrant(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if got := r.PostForm.Get("grant_type"); got != "refresh_token" {
+			t.Errorf("grant_type: %q", got)
+		}
+		if got := r.PostForm.Get("refresh_token"); got != "rtk_old" {
+			t.Errorf("refresh_token: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"atk_x","token_type":"Bearer","expires_in":1200,"refresh_token":"rtk_rotated"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	prev := overrideTokenURL(srv.URL)
+	defer prev()
+
+	tok, err := RefreshToken(context.Background(), "client_x", "", "rtk_old")
+	if err != nil {
+		t.Fatalf("RefreshToken: %v", err)
+	}
+	if tok.AccessToken != "atk_x" || tok.RefreshToken != "rtk_rotated" {
+		t.Fatalf("tokens: %+v", tok)
+	}
+}
+
+func TestPostToken_ErrorBodyIsSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"code expired"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	prev := overrideTokenURL(srv.URL)
+	defer prev()
+
+	_, err := ExchangeCode(context.Background(), "c", "", "code", "http://x/cb", "v")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid_grant") || !strings.Contains(err.Error(), "code expired") {
+		t.Fatalf("error did not surface body: %v", err)
+	}
+}
+
+func TestLoopbackServer_CapturesCodeAndState(t *testing.T) {
+	ls, err := NewLoopbackServer()
+	if err != nil {
+		t.Fatalf("NewLoopbackServer: %v", err)
+	}
+	t.Cleanup(ls.Close)
+
+	go func() {
+		_, _ = http.Get(ls.URL + "?code=auth_code_1&state=s_1")
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	resp, err := ls.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if resp.Code != "auth_code_1" || resp.State != "s_1" {
+		t.Fatalf("got %+v", resp)
+	}
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -36,11 +36,44 @@ const envProjectID = "REVCAT_PROJECT_ID"
 
 const defaultProfile = "default"
 
-// Profile is the credential set we persist per name.
+// AuthType discriminates between the two credential models a profile
+// can hold. Default ("" or "secret_key") is the original v2 secret-key
+// flow. "oauth" stores an access/refresh token pair.
+type AuthType string
+
+const (
+	AuthTypeSecretKey AuthType = "secret_key"
+	AuthTypeOAuth     AuthType = "oauth"
+)
+
+// Profile is the credential set we persist per name. Supports two auth
+// models discriminated by AuthType:
+//
+//   - secret_key (default): SecretKey is set, tokens are empty.
+//   - oauth: AccessToken/RefreshToken/ExpiresAt are set, SecretKey empty.
+//
+// Profiles created before AuthType existed default to secret_key on read.
 type Profile struct {
-	Name      string `json:"name"`
-	SecretKey string `json:"secret_key"`
-	ProjectID string `json:"project_id,omitempty"`
+	Name      string   `json:"name"`
+	AuthType  AuthType `json:"auth_type,omitempty"`
+	SecretKey string   `json:"secret_key,omitempty"`
+	ProjectID string   `json:"project_id,omitempty"`
+
+	// OAuth fields (only set when AuthType == AuthTypeOAuth).
+	AccessToken  string `json:"access_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresAt    int64  `json:"expires_at_ms,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+	ClientID     string `json:"client_id,omitempty"`
+}
+
+// EffectiveAuthType returns AuthType, defaulting to secret_key for legacy
+// profiles that predate the field.
+func (p *Profile) EffectiveAuthType() AuthType {
+	if p.AuthType == "" {
+		return AuthTypeSecretKey
+	}
+	return p.AuthType
 }
 
 // ErrNoProfile is returned when the requested profile doesn't exist.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -31,9 +31,6 @@ const envBypassKeychain = "REVCAT_BYPASS_KEYCHAIN"
 // envProfile picks the active profile when --profile is not set.
 const envProfile = "REVCAT_PROFILE"
 
-// envProjectID lets a script override the stored project id.
-const envProjectID = "REVCAT_PROJECT_ID"
-
 const defaultProfile = "default"
 
 // AuthType discriminates between the two credential models a profile
@@ -108,7 +105,6 @@ func Resolve(store Store, flagProfile string) (*Profile, error) {
 		return &Profile{
 			Name:      "$" + envKeyOverride,
 			SecretKey: key,
-			ProjectID: os.Getenv(envProjectID),
 		}, nil
 	}
 	name := flagProfile
@@ -126,9 +122,6 @@ func Resolve(store Store, flagProfile string) (*Profile, error) {
 	p, err := store.Get(name)
 	if err != nil {
 		return nil, err
-	}
-	if pid := os.Getenv(envProjectID); pid != "" {
-		p.ProjectID = pid
 	}
 	return p, nil
 }

--- a/internal/auth/env.go
+++ b/internal/auth/env.go
@@ -1,0 +1,7 @@
+package auth
+
+import "os"
+
+// getenv is a wrapper so envOrEmpty in oauth.go can be stubbed in tests
+// without leaking os.Getenv into the test surface.
+func getenv(key string) string { return os.Getenv(key) }

--- a/internal/auth/env.go
+++ b/internal/auth/env.go
@@ -1,7 +1,0 @@
-package auth
-
-import "os"
-
-// getenv is a wrapper so envOrEmpty in oauth.go can be stubbed in tests
-// without leaking os.Getenv into the test surface.
-func getenv(key string) string { return os.Getenv(key) }

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -1,0 +1,119 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/akshitkrnagpal/revcat/internal/api"
+)
+
+// envClientID lets the user override the baked-in OAuth client_id.
+const envClientID = "REVCAT_OAUTH_CLIENT_ID"
+
+// EmbeddedClientID is the OAuth client_id baked into release builds.
+// Empty until RevenueCat registers revcat as a public OAuth client.
+//
+// Override at build time via:
+//
+//	go build -ldflags "-X github.com/akshitkrnagpal/revcat/internal/auth.EmbeddedClientID=<id>"
+//
+// Or at runtime via the REVCAT_OAUTH_CLIENT_ID env var.
+var EmbeddedClientID = ""
+
+// OAuthClientID returns the active client_id, env override taking
+// precedence over the embedded constant.
+func OAuthClientID() string {
+	if v := envClientID; v != "" {
+		// resolved below
+	}
+	if v := envOrEmpty(envClientID); v != "" {
+		return v
+	}
+	return EmbeddedClientID
+}
+
+// OAuthTokenSource is an api.TokenSource backed by an OAuth profile. It
+// auto-refreshes when the access_token is within refreshSkew of expiry
+// and persists the new tokens back via the Store.
+type OAuthTokenSource struct {
+	store   Store
+	profile *Profile
+	mu      sync.Mutex
+}
+
+// refreshSkew - refresh slightly before actual expiry to avoid mid-flight
+// 401s from clock drift / network latency.
+const refreshSkew = 60 * time.Second
+
+// NewOAuthTokenSource constructs a refreshing token source bound to a
+// profile. The profile is updated in place + persisted on every refresh.
+func NewOAuthTokenSource(store Store, profile *Profile) *OAuthTokenSource {
+	return &OAuthTokenSource{store: store, profile: profile}
+}
+
+// Token returns a valid access token, refreshing transparently if needed.
+func (s *OAuthTokenSource) Token(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.profile.AccessToken == "" {
+		return "", errors.New("oauth profile has no access token; run `revcat auth login --oauth` again")
+	}
+	if !s.expiringSoon() {
+		return s.profile.AccessToken, nil
+	}
+	if s.profile.RefreshToken == "" {
+		return "", errors.New("oauth access token expired and no refresh_token; run `revcat auth login --oauth` again")
+	}
+	clientID := s.profile.ClientID
+	if clientID == "" {
+		clientID = OAuthClientID()
+	}
+	if clientID == "" {
+		return "", errors.New("oauth client_id is empty; set REVCAT_OAUTH_CLIENT_ID or use a build that has one baked in")
+	}
+	tok, err := api.RefreshToken(ctx, clientID, "", s.profile.RefreshToken)
+	if err != nil {
+		return "", fmt.Errorf("oauth refresh: %w", err)
+	}
+	s.applyToken(tok)
+	if err := s.store.Set(s.profile); err != nil {
+		// Surfacing the persistence error blocks the request but the
+		// in-memory token is still valid for this call. Bubble up so
+		// the user knows they need to re-login if persistence is
+		// genuinely broken.
+		return "", fmt.Errorf("persist refreshed tokens: %w", err)
+	}
+	return s.profile.AccessToken, nil
+}
+
+func (s *OAuthTokenSource) expiringSoon() bool {
+	if s.profile.ExpiresAt == 0 {
+		return false // token has no expiry recorded; assume usable
+	}
+	deadline := time.UnixMilli(s.profile.ExpiresAt).Add(-refreshSkew)
+	return time.Now().After(deadline)
+}
+
+// applyToken updates the profile struct from a fresh token response.
+// Refresh tokens may be rotated or omitted; we keep the existing one
+// when the response doesn't return a new one.
+func (s *OAuthTokenSource) applyToken(t *api.TokenResponse) {
+	s.profile.AccessToken = t.AccessToken
+	if t.RefreshToken != "" {
+		s.profile.RefreshToken = t.RefreshToken
+	}
+	if t.ExpiresIn > 0 {
+		s.profile.ExpiresAt = time.Now().Add(time.Duration(t.ExpiresIn) * time.Second).UnixMilli()
+	}
+	if t.Scope != "" {
+		s.profile.Scope = t.Scope
+	}
+}
+
+// envOrEmpty is a tiny wrapper around os.Getenv so callers can stub
+// during tests if needed.
+var envOrEmpty = func(key string) string { return getenv(key) }

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -14,22 +15,19 @@ import (
 const envClientID = "REVCAT_OAUTH_CLIENT_ID"
 
 // EmbeddedClientID is the OAuth client_id baked into release builds.
-// Empty until RevenueCat registers revcat as a public OAuth client.
+// Defaults to revcat's public PKCE client registered with RevenueCat.
 //
 // Override at build time via:
 //
 //	go build -ldflags "-X github.com/akshitkrnagpal/revcat/internal/auth.EmbeddedClientID=<id>"
 //
 // Or at runtime via the REVCAT_OAUTH_CLIENT_ID env var.
-var EmbeddedClientID = ""
+var EmbeddedClientID = "UmV2Q2F0"
 
 // OAuthClientID returns the active client_id, env override taking
 // precedence over the embedded constant.
 func OAuthClientID() string {
-	if v := envClientID; v != "" {
-		// resolved below
-	}
-	if v := envOrEmpty(envClientID); v != "" {
+	if v := os.Getenv(envClientID); v != "" {
 		return v
 	}
 	return EmbeddedClientID
@@ -114,6 +112,3 @@ func (s *OAuthTokenSource) applyToken(t *api.TokenResponse) {
 	}
 }
 
-// envOrEmpty is a tiny wrapper around os.Getenv so callers can stub
-// during tests if needed.
-var envOrEmpty = func(key string) string { return getenv(key) }

--- a/internal/cliutil/cliutil.go
+++ b/internal/cliutil/cliutil.go
@@ -3,11 +3,18 @@
 package cliutil
 
 import (
+	"errors"
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/akshitkrnagpal/revcat/internal/api"
 	authstore "github.com/akshitkrnagpal/revcat/internal/auth"
+	"github.com/akshitkrnagpal/revcat/internal/project"
 )
+
+// envProjectID is the env var that overrides revcat.toml.
+const envProjectID = "REVCAT_PROJECT_ID"
 
 // BypassKeychain reads the global --bypass-keychain flag from cobra root.
 func BypassKeychain(cmd *cobra.Command) bool {
@@ -27,13 +34,71 @@ func Profile(cmd *cobra.Command) string {
 	return flag.Value.String()
 }
 
+// ProjectIDFlag reads the global --project-id flag from cobra root.
+func ProjectIDFlag(cmd *cobra.Command) string {
+	flag := cmd.Root().PersistentFlags().Lookup("project-id")
+	if flag == nil {
+		return ""
+	}
+	return flag.Value.String()
+}
+
+// ResolveProjectID returns the active RevenueCat project id with this
+// precedence:
+//
+//  1. --project-id flag
+//  2. REVCAT_PROJECT_ID env
+//  3. revcat.toml walking up from cwd (Terraform-style per-repo context)
+//  4. profile.ProjectID (legacy: secret-key profiles bind one at login)
+//
+// Returns empty string if none of those produce a value. Callers that
+// need a project id should error with a hint pointing at `revcat init`.
+func ResolveProjectID(cmd *cobra.Command, profile *authstore.Profile) string {
+	if v := ProjectIDFlag(cmd); v != "" {
+		return v
+	}
+	if v := os.Getenv(envProjectID); v != "" {
+		return v
+	}
+	if cfg, err := project.LoadFromCwd(); err == nil && cfg.ProjectID != "" {
+		return cfg.ProjectID
+	}
+	if profile != nil {
+		return profile.ProjectID
+	}
+	return ""
+}
+
+// ErrNoProjectID is returned by RequireProjectID when no project id
+// could be resolved.
+var ErrNoProjectID = errors.New("no project id - pass --project-id, set REVCAT_PROJECT_ID, run `revcat init` in your repo, or attach one to the profile")
+
+// RequireProjectID is ResolveProjectID + a hint-friendly error when
+// nothing is configured.
+func RequireProjectID(cmd *cobra.Command, profile *authstore.Profile) (string, error) {
+	if id := ResolveProjectID(cmd, profile); id != "" {
+		return id, nil
+	}
+	return "", ErrNoProjectID
+}
+
 // Client opens the credential store, resolves the active profile, and
 // returns a ready-to-use API client. Returns an error if the profile is
 // missing or the store can't be opened. Most commands use this.
 //
+// Project id is resolved via ResolveProjectID, so per-repo revcat.toml
+// and the --project-id flag both apply.
+//
 // For OAuth profiles, the returned client carries a refreshing
 // TokenSource that updates the stored profile on each refresh.
 func Client(cmd *cobra.Command) (*api.Client, *authstore.Profile, error) {
+	return ClientForProject(cmd, "")
+}
+
+// ClientForProject is like Client but lets the caller force a specific
+// project_id (overriding flag/env/toml). Used by `revcat init` after the
+// user picks a project but hasn't written revcat.toml yet.
+func ClientForProject(cmd *cobra.Command, projectIDOverride string) (*api.Client, *authstore.Profile, error) {
 	store, err := authstore.Open(BypassKeychain(cmd))
 	if err != nil {
 		return nil, nil, err
@@ -42,8 +107,12 @@ func Client(cmd *cobra.Command) (*api.Client, *authstore.Profile, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	pid := projectIDOverride
+	if pid == "" {
+		pid = ResolveProjectID(cmd, prof)
+	}
 	opts := api.Options{
-		ProjectID: prof.ProjectID,
+		ProjectID: pid,
 		Version:   cmd.Root().Version,
 	}
 	if prof.EffectiveAuthType() == authstore.AuthTypeOAuth {

--- a/internal/cliutil/cliutil.go
+++ b/internal/cliutil/cliutil.go
@@ -30,6 +30,9 @@ func Profile(cmd *cobra.Command) string {
 // Client opens the credential store, resolves the active profile, and
 // returns a ready-to-use API client. Returns an error if the profile is
 // missing or the store can't be opened. Most commands use this.
+//
+// For OAuth profiles, the returned client carries a refreshing
+// TokenSource that updates the stored profile on each refresh.
 func Client(cmd *cobra.Command) (*api.Client, *authstore.Profile, error) {
 	store, err := authstore.Open(BypassKeychain(cmd))
 	if err != nil {
@@ -39,10 +42,14 @@ func Client(cmd *cobra.Command) (*api.Client, *authstore.Profile, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	c := api.New(api.Options{
-		SecretKey: prof.SecretKey,
+	opts := api.Options{
 		ProjectID: prof.ProjectID,
 		Version:   cmd.Root().Version,
-	})
-	return c, prof, nil
+	}
+	if prof.EffectiveAuthType() == authstore.AuthTypeOAuth {
+		opts.TokenSource = authstore.NewOAuthTokenSource(store, prof)
+	} else {
+		opts.SecretKey = prof.SecretKey
+	}
+	return api.New(opts), prof, nil
 }

--- a/internal/cliutil/projectid_test.go
+++ b/internal/cliutil/projectid_test.go
@@ -1,0 +1,94 @@
+package cliutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	authstore "github.com/akshitkrnagpal/revcat/internal/auth"
+)
+
+// rootWithFlags constructs a cobra root with the global --project-id flag
+// wired up, mirroring commands/root.go. Used to drive ProjectIDFlag /
+// ResolveProjectID under test without importing the commands package
+// (which would create a cycle).
+func rootWithFlags(t *testing.T) *cobra.Command {
+	t.Helper()
+	root := &cobra.Command{Use: "revcat"}
+	pf := root.PersistentFlags()
+	pf.String("project-id", "", "")
+	pf.String("profile", "", "")
+	pf.Bool("bypass-keychain", false, "")
+	return root
+}
+
+func TestResolveProjectID_FlagWins(t *testing.T) {
+	root := rootWithFlags(t)
+	if err := root.PersistentFlags().Set("project-id", "from_flag"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("REVCAT_PROJECT_ID", "from_env")
+	prof := &authstore.Profile{ProjectID: "from_profile"}
+
+	got := ResolveProjectID(root, prof)
+	if got != "from_flag" {
+		t.Fatalf("got %q, want from_flag", got)
+	}
+}
+
+func TestResolveProjectID_EnvWinsOverProfile(t *testing.T) {
+	root := rootWithFlags(t)
+	t.Setenv("REVCAT_PROJECT_ID", "from_env")
+	prof := &authstore.Profile{ProjectID: "from_profile"}
+
+	got := ResolveProjectID(root, prof)
+	if got != "from_env" {
+		t.Fatalf("got %q, want from_env", got)
+	}
+}
+
+func TestResolveProjectID_TomlWinsOverProfile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "revcat.toml"),
+		[]byte(`project_id = "from_toml"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	t.Setenv("REVCAT_PROJECT_ID", "")
+
+	root := rootWithFlags(t)
+	prof := &authstore.Profile{ProjectID: "from_profile"}
+
+	got := ResolveProjectID(root, prof)
+	if got != "from_toml" {
+		t.Fatalf("got %q, want from_toml", got)
+	}
+}
+
+func TestResolveProjectID_FallsBackToProfile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("REVCAT_PROJECT_ID", "")
+
+	root := rootWithFlags(t)
+	prof := &authstore.Profile{ProjectID: "from_profile"}
+
+	got := ResolveProjectID(root, prof)
+	if got != "from_profile" {
+		t.Fatalf("got %q, want from_profile", got)
+	}
+}
+
+func TestResolveProjectID_EmptyWhenNothingConfigured(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("REVCAT_PROJECT_ID", "")
+
+	root := rootWithFlags(t)
+	got := ResolveProjectID(root, &authstore.Profile{})
+	if got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,0 +1,120 @@
+// Package project loads per-repo revcat configuration. The config lives
+// in revcat.toml at the repo root and is committed alongside the source,
+// the same way Terraform pins its providers in main.tf.
+//
+// Resolution: walked up from the current working directory until a
+// revcat.toml is found (like .git or go.mod). Missing file is not an
+// error - it just means "no project context", and callers fall back to
+// flag/env/legacy-profile.
+package project
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// FileName is the per-repo config file. Walked up from cwd.
+const FileName = "revcat.toml"
+
+// Config is the parsed revcat.toml. Apps is optional - useful for store
+// bridges where multiple platform bundles share a project.
+type Config struct {
+	ProjectID string `toml:"project_id"`
+	Apps      []App  `toml:"apps"`
+
+	// Path is the absolute path to the file this Config was loaded from.
+	// Empty if no file was found (default Config{}).
+	Path string `toml:"-"`
+}
+
+// App is one platform bundle declared in revcat.toml. Optional metadata
+// only; commands resolve apps by id.
+type App struct {
+	ID   string `toml:"id"`
+	Name string `toml:"name,omitempty"`
+}
+
+// ErrNotFound is returned by Load when no revcat.toml is found walking
+// up from startDir to the filesystem root.
+var ErrNotFound = errors.New("no revcat.toml found")
+
+// Load walks up from startDir looking for revcat.toml. Returns
+// ErrNotFound when no file exists; other errors (parse, IO) bubble up
+// unwrapped.
+func Load(startDir string) (*Config, error) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return nil, err
+	}
+	for {
+		path := filepath.Join(dir, FileName)
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return readFile(path)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil, ErrNotFound
+		}
+		dir = parent
+	}
+}
+
+// LoadFromCwd is Load(os.Getwd()).
+func LoadFromCwd() (*Config, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	return Load(cwd)
+}
+
+func readFile(path string) (*Config, error) {
+	var cfg Config
+	meta, err := toml.DecodeFile(path, &cfg)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if undecoded := meta.Undecoded(); len(undecoded) > 0 {
+		// Tolerate forward-compatible keys (env blocks etc) - the
+		// decoder ignored them, we just don't surface a warning.
+		_ = undecoded
+	}
+	cfg.Path = path
+	return &cfg, nil
+}
+
+// Save writes cfg to path atomically. Used by `revcat init`.
+func Save(path string, cfg *Config) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".revcat-toml-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+
+	enc := toml.NewEncoder(tmp)
+	if err := enc.Encode(toCanonical(cfg)); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
+}
+
+// toCanonical produces a stable, comment-free shape for the encoder so
+// the file we write looks the same across runs (Path is a transient
+// loaded-from field, not on-disk data).
+type canonical struct {
+	ProjectID string `toml:"project_id"`
+	Apps      []App  `toml:"apps,omitempty"`
+}
+
+func toCanonical(cfg *Config) canonical {
+	return canonical{ProjectID: cfg.ProjectID, Apps: cfg.Apps}
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,0 +1,114 @@
+package project
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad_FindsFileInStartDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, FileName), `project_id = "proj_abc"`)
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.ProjectID != "proj_abc" {
+		t.Fatalf("ProjectID: %q", cfg.ProjectID)
+	}
+	if cfg.Path != filepath.Join(dir, FileName) {
+		t.Fatalf("Path: %q", cfg.Path)
+	}
+}
+
+func TestLoad_WalksUpToParent(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(root, FileName), `project_id = "proj_root"`)
+
+	cfg, err := Load(nested)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.ProjectID != "proj_root" {
+		t.Fatalf("ProjectID: %q", cfg.ProjectID)
+	}
+}
+
+func TestLoad_NotFoundWhenNoFileAnywhere(t *testing.T) {
+	dir := t.TempDir()
+	_, err := Load(dir)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestLoad_ParsesAppsArray(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, FileName), `
+project_id = "proj_x"
+
+[[apps]]
+id   = "app_ios"
+name = "iOS"
+
+[[apps]]
+id   = "app_android"
+name = "Android"
+`)
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := len(cfg.Apps); got != 2 {
+		t.Fatalf("apps: %d", got)
+	}
+	if cfg.Apps[0].ID != "app_ios" || cfg.Apps[1].ID != "app_android" {
+		t.Fatalf("apps: %+v", cfg.Apps)
+	}
+}
+
+func TestLoad_MalformedReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, FileName), `project_id =`)
+
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestSaveAndReload_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, FileName)
+	in := &Config{
+		ProjectID: "proj_save",
+		Apps: []App{
+			{ID: "app_a", Name: "A"},
+			{ID: "app_b"},
+		},
+	}
+	if err := Save(path, in); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	out, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if out.ProjectID != "proj_save" || len(out.Apps) != 2 {
+		t.Fatalf("roundtrip: %+v", out)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/skills/revcat-getting-started/SKILL.md
+++ b/skills/revcat-getting-started/SKILL.md
@@ -23,7 +23,7 @@ Pre-built binaries for every platform are on the [GitHub Releases page](https://
 
 ## Auth (one-time)
 
-revcat reads a v2 secret key (`sk_...`) and stores it in the OS keychain.
+revcat supports two credential models. The default is a v2 secret key:
 
 Pipe the key in via stdin so it does not land in your shell history:
 
@@ -34,6 +34,13 @@ revcat auth doctor             # verify
 
 `--secret-key sk_...` works too, but the key is visible in shell history and
 process listings. Prefer `--secret-key-stdin` for production and CI.
+
+Browser-based OAuth (PKCE) login is also supported:
+
+```sh
+revcat auth login --oauth --name my-app
+# tokens auto-refresh on every command thereafter
+```
 
 For CI / Docker (no keychain), use one of:
 


### PR DESCRIPTION
## Summary
- `revcat auth login --oauth` runs the PKCE flow. Saves tokens-only (no project binding); auto-refreshes via a TokenSource on the API client.
- New `revcat init` writes a per-repo `revcat.toml` pinning `project_id` (+ optional apps). Walked up from cwd like `.git` / `go.mod`, so any command run inside the repo inherits the project automatically.
- New global `--project-id` flag overrides per-invocation. Resolution: `--project-id` > `REVCAT_PROJECT_ID` > nearest `revcat.toml` > profile binding (legacy backcompat for secret-key profiles).
- Public OAuth client `UmV2Q2F0` baked in (per RC support email confirming this is a public PKCE client). Override with `REVCAT_OAUTH_CLIENT_ID` or `-ldflags '-X .../auth.EmbeddedClientID=<id>'`.
- Existing secret-key login is unchanged: still binds `project_id` at login time, still works without `revcat.toml`.

## Motivation

OAuth access tokens are account-scoped — they work against any project the user has access to. Binding one project at login time means the credential and the project context get tangled, and switching projects requires re-logging in. `revcat.toml` mirrors how Terraform pins providers / backends in the repo: commit it, and every `cd` into the repo gives you the right context for free.

## How to run

```sh
git checkout oauth-support && go build -o /tmp/revcat ./cmd/revcat

# 1. Log in (account-scoped, no project picker)
/tmp/revcat auth login --oauth --name oauth-test

# 2. Bind project context for this repo
cd /path/to/your/repo
/tmp/revcat --profile oauth-test init     # interactive: pick project + apps
# or scripted:
/tmp/revcat --profile oauth-test init --project-id projaac376d8 --no-apps

# 3. Use any read or write command end-to-end - revcat.toml is picked up automatically
/tmp/revcat --profile oauth-test offerings list
/tmp/revcat --profile oauth-test entitlements list
```

## Test plan

- [ ] `auth login --oauth` opens browser, saves tokens, prints "next: cd into your repo and run `revcat init`". No project picker.
- [ ] `auth status --validate` shows `auth_type: oauth`, `project_source` (the path to revcat.toml or "-" before init), and `validation OK`.
- [ ] `revcat init` lists projects, lets you pick one, optionally lists apps for selection, writes revcat.toml at cwd.
- [ ] `revcat init --project-id projXXX --no-apps` (scripted) writes revcat.toml without prompts.
- [ ] `revcat init` refuses to overwrite without `--force`.
- [ ] After init, `cd` anywhere under the repo - any project-scoped command picks up the project_id without a flag.
- [ ] `--project-id projYYY` global flag overrides revcat.toml for one invocation.
- [ ] `REVCAT_PROJECT_ID=projZZZ` env overrides revcat.toml.
- [ ] After 1h (or sooner via clock skew) a follow-up command transparently refreshes the OAuth access token; `auth status` shows the new expiry.
- [ ] Existing secret-key profiles continue to work unchanged - their bound `project_id` is still honored as the lowest-precedence fallback.

## File format

```toml
project_id = "projaac376d8"

[[apps]]
id   = "app_ios_xxx"
name = "HookBell iOS"

[[apps]]
id   = "app_android_yyy"
name = "HookBell Android"
```

Future-friendly: forward-incompatible TOML keys (e.g. `[env.staging]`) decode without error.

## What this does NOT touch
- Secret-key login flow is unchanged. `revcat auth login --secret-key sk_...` still binds `project_id` to the profile.
- `audit-logs` continues to require a secret key (RC's OAuth scope set excludes audit logs).
- Existing keychain profiles deserialize unchanged - `auth_type` defaults to `secret_key` when missing.

## Implementation notes
- PKCE: 32 random bytes -> base64url-no-pad verifier (43 chars), S256 challenge.
- Redirect URI: `http://127.0.0.1:<random-port>/callback` per RFC 8252.
- Refresh skew: 60s before `expires_at`; mutex-guarded so concurrent commands don't double-refresh.
- ProjectID resolution lives in `cliutil.ResolveProjectID` and `cliutil.Client` so every command picks it up uniformly. New commands that need a project id should call `RequireProjectID` for a hint-friendly error.

## Tests
- `internal/api/oauth_test.go`: PKCE correctness, AuthorizeURL shape, ExchangeCode/RefreshToken form encoding, error-body surfacing, loopback callback capture.
- `internal/project/project_test.go`: walk-up lookup, ErrNotFound, malformed-file error, save/load roundtrip.
- `internal/cliutil/projectid_test.go`: full precedence chain (flag > env > toml > profile > empty).