### PR TITLE
skills: storefront-debug + Test Store + v1-fallback coverage

### DIFF
--- a/skills/revcat-commands/SKILL.md
+++ b/skills/revcat-commands/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: revcat-commands
-description: Use when constructing a revcat command. Reference for every subcommand with real syntax and examples for entitlements, offerings, products, paywalls, subscribers, subscriptions, webhooks, metrics, charts, audit-logs. Triggers on "revcat <command>", "how do I X with revcat".
+description: Use when constructing or verifying a revcat command, or when looking up which commands exist for a given resource. Reference for every subcommand with real syntax and examples for entitlements, offerings, packages, products, paywalls, subscribers, subscriptions, webhooks, metrics, charts, audit-logs, virtual-currencies, apps. Triggers on "revcat <command>", "how do I X with revcat", "which revcat command", "is there a revcat for", "what flags does revcat <subcommand> take", "list / view / create / delete / update with revcat".
 ---
 
 # revcat - command reference
@@ -12,6 +12,7 @@ Conventions:
 - `<id>` = literal id RC returns. Often a lookup_key like `premium`, sometimes an internal id like `pkg_xxx`.
 - `--file <path>` = JSON body on disk (or `-` for stdin). Used wherever the v2 schema is broad.
 - `-y / --confirm` = skip the destructive-action prompt.
+- **Flags are scoped to the subcommand.** Don't assume a flag that works on one subcommand works on another. `revcat packages list` takes `--offering`, NOT `--app-id`. `revcat products list` has no per-app filter at all (filter by `app_id` in the JSON output instead). Always check `--help` on the exact subcommand if a guess doesn't take.
 
 ## auth
 

--- a/skills/revcat-storefront-debug/SKILL.md
+++ b/skills/revcat-storefront-debug/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: revcat-storefront-debug
+description: Use when the SDK sees 0 packages in an offering, when a Test Store / App Store / Play / Stripe product isn't reaching the client, or when a freshly-created offering isn't returning what the user expects. Triggers on "0 packages", "no packages", "SDK not seeing", "test store", "products not in offering", "offering not working", "current_offering_id but empty packages", "fetchOfferings empty", "Purchases.getOfferings returned nothing".
+---
+
+# revcat - storefront / offering delivery debugging
+
+The SDK call (`Purchases.getOfferings()` on iOS/Android, `purchases.getOfferings()` on web) returns whatever the v1 endpoint `/v1/subscribers/{user_id}/offerings` returns. **revcat itself only wraps v2 endpoints**, so if you need to see the v1 view directly, you fall back to curl. The diagnostic flow below is the canonical "why isn't my offering working" walk.
+
+## When to reach for this skill
+
+The user says any of:
+
+- "the SDK is seeing zero packages"
+- "my offering returns empty"
+- "I added products to my package but they're not showing up"
+- "Test Store products aren't loading"
+- "App Store products aren't reaching the SDK"
+- "`fetchOfferings` returns the offering id but no packages"
+
+If the user is just constructing a command, route to `revcat-commands` instead. This skill is for diagnosing why the SDK isn't seeing what the dashboard shows.
+
+## Diagnostic flow (in order)
+
+Run these top-down. Stop at the first level that's wrong — that's the broken layer.
+
+### 1. Confirm the offering exists and is current
+
+```sh
+revcat offerings list
+```
+
+The current offering is marked with `*`. The SDK's `current_offering_id` only returns this one. If you see your offering but it isn't current, set it:
+
+```sh
+revcat offerings set-current <id>
+```
+
+### 2. Confirm packages are attached to the offering
+
+```sh
+revcat packages list --offering <offering_id>
+```
+
+If this is empty, the offering has no packages. Create them:
+
+```sh
+revcat packages create --file ./package.json
+```
+
+(Body shape: `{identifier, offering_id}`. Use `$rc_monthly`, `$rc_annual`, etc. for RC's standard identifiers.)
+
+### 3. Confirm products are attached to each package
+
+```sh
+revcat packages products <pkg_id>
+```
+
+If this is empty, the package isn't bound to a product yet. Attach:
+
+```sh
+revcat packages attach <pkg_id> <product_id>
+```
+
+If the output shows products but `display_name` is empty, that's the v2 API's normal shape — the display name lives on the product, not the binding. Run `revcat products view <product_id>` to see it.
+
+### 4. Confirm each product is bound to a Store app and is reachable
+
+```sh
+revcat products view <product_id>
+```
+
+Look at `app_id`. The product must be attached to an app entry that matches the runtime store (App Store, Play Store, Stripe, **Test Store**). One product per store + one app entry per store.
+
+```sh
+revcat apps list
+```
+
+Confirm the product's `app_id` matches the app for the runtime store you're testing against.
+
+### 5. (App Store / Play only) Push the product to the live store
+
+```sh
+revcat products push-to-store <product_id>
+```
+
+This is the v2 endpoint that triggers RC's sync to the underlying store. Must be run after creating a product if you want the App Store / Play to see it.
+
+### 6. (Test Store only) Set a price in the RC dashboard UI
+
+**The v2 API does not expose Test Store prices.** This is a documented RC limitation as of late 2025/2026. If the offering targets the Test Store app, every product must have a price set via the dashboard UI:
+
+> https://app.revenuecat.com/projects/{project_id}/apps/{test_store_app_id}/products → click each product → set price.
+
+Without prices, `/v1/subscribers/{user_id}/offerings` returns the offering with `packages: []`, which is exactly the "SDK sees 0 packages" symptom. revcat cannot fix this from the CLI.
+
+### 7. Verify what the SDK will actually receive (v1 endpoint, curl fallback)
+
+revcat doesn't wrap v1, so this is the one place curl is the right tool:
+
+```sh
+# Use the PUBLIC SDK key (one of the test or production public keys), not the
+# v2 secret key. Get it via:
+#   revcat apps public-keys <app_id>
+TEST_KEY="<public_key>"
+curl -s "https://api.revenuecat.com/v1/subscribers/<user_id>/offerings" \
+    -H "Authorization: Bearer $TEST_KEY" \
+    -H "X-Platform: iOS"
+```
+
+A healthy response looks like:
+
+```json
+{
+  "current_offering_id": "default",
+  "offerings": [
+    {
+      "identifier": "default",
+      "packages": [
+        { "identifier": "$rc_monthly", "platform_product_identifier": "..." }
+      ]
+    }
+  ]
+}
+```
+
+If `packages` is empty here, the SDK will also see empty. The cause is upstream — re-check steps 1-6.
+
+## Common root causes (with the layer they show up at)
+
+| Symptom in v1 offerings response | Most likely cause | Layer |
+|---|---|---|
+| Offering missing entirely | Not marked current | Step 1 |
+| Offering exists, `packages: []` | No packages attached, or none attached to a product, or Test Store product has no price | Steps 2 / 3 / 6 |
+| Packages exist but `platform_product_identifier` is null | Product not pushed to store, or wrong `X-Platform` header | Steps 4 / 5 |
+| Different products on iOS vs Android | One store missing the product binding | Step 4 |
+
+## Where revcat does NOT cover the flow
+
+revcat wraps the v2 RC API. It does not cover:
+
+- **Test Store price setting** (dashboard UI only, no v2 endpoint exists)
+- **Per-subscriber offering preview** (v1 endpoint, use curl as shown in step 7)
+- **Sync status to App Store Connect / Play Console** beyond `push-to-store`
+
+If the user reaches for curl on any v2 endpoint, that's a revcat bug worth filing. If they reach for curl on a v1 endpoint or a dashboard-only operation, that's expected and this skill should call it out.

--- a/skills/revcat-troubleshooting/SKILL.md
+++ b/skills/revcat-troubleshooting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: revcat-troubleshooting
-description: Use when a revcat command fails or shows an error. Common errors: 401 unauthorized, no profile, no project_id, 404 customer/subscription, partner-tier endpoints, paywall PUT failures, ndjson parsing. Triggers on revcat error output, "revcat doesn't work".
+description: Use when a revcat command fails or shows an error. Common errors: 401 unauthorized, no profile, no project_id, 404 customer/subscription, partner-tier endpoints, paywall PUT failures, ndjson parsing, Test Store quirks, v1-only endpoints, dashboard-only operations. Triggers on revcat error output, "revcat doesn't work", "command not supported", "atob error", "endpoint missing".
 ---
 
 # revcat - troubleshooting
@@ -74,8 +74,36 @@ revcat caps JSON file input at 4 MB to defend against accidental binary blobs. I
 
 `--no-color` (or `NO_COLOR=1`) helps in terminals that don't speak ANSI. For dumb pipes, force JSON: `--output json`.
 
+## Test Store quirks ("my offering returns 0 packages on the SDK")
+
+The Test Store is RC's sandbox-style storefront for development. It has two gotchas:
+
+1. **Prices are dashboard-only.** v2 has no endpoint for setting prices on Test Store products. revcat cannot help here — set the price in the RC dashboard UI under each product.
+2. **A product without a price is invisible to the SDK.** `/v1/subscribers/{user_id}/offerings` returns `packages: []` for offerings whose products have no Test Store price. The dashboard will show the product attached to the package; the SDK will still see nothing.
+
+If the user is debugging this end-to-end, route to `revcat-storefront-debug` — that skill walks the full diagnostic flow.
+
+## v1-only endpoints (revcat does not wrap these)
+
+revcat tracks v2. The v1 surface is intentionally out of scope. The few v1 endpoints that come up in real debugging:
+
+- `GET /v1/subscribers/{user_id}/offerings` - what the SDK actually receives. Use this to diff "what the dashboard shows" vs "what `Purchases.getOfferings()` returns." See `revcat-storefront-debug` for the curl pattern.
+- `POST /v1/subscribers/{user_id}/receipts` - validate a store receipt. Used by SDKs internally; not a debugging endpoint.
+
+When you fall back to curl for v1, use the **public SDK key** (one of the per-platform public keys), not the v2 secret key. Pull it via `revcat apps public-keys <app_id>`.
+
+## Dashboard-only operations
+
+A small set of operations have no v2 endpoint at all — revcat cannot wrap what doesn't exist. Known cases as of revcat's current shipped version:
+
+- Test Store product prices (covered above)
+- StoreKit configuration generation for local Xcode testing (export from dashboard manually)
+- Webhook signing-secret rotation (rotate via dashboard, then re-fetch with `revcat webhooks view`)
+
+If the user reaches for the dashboard for one of these, that's expected. If they reach for the dashboard for anything else and a v2 endpoint exists for it, that's a revcat coverage gap worth filing.
+
 ## Where revcat does NOT work
 
 - Project create, app CRUD, collaborators - need a partner-tier API key.
 - An events firehose - RC delivers lifecycle events via webhooks (`revcat webhooks`), not a REST stream.
-- Anything not in `revcat <group> --help` - revcat tracks v2; v1-only endpoints are not wrapped.
+- Anything not in `revcat <group> --help` - revcat tracks v2; v1-only endpoints are not wrapped (see above for the curl fallback).


### PR DESCRIPTION
## Summary

A recent debugging session in another project (hookbell, working on RC Test Store setup) hit a 30-minute dead-end where revcat's CLI was correct but the agent couldn't find the right workflow because the skills didn't cover Test Store specifics or the v1 offerings preview endpoint. This PR fills those gaps.

## Changes

**New skill: \`revcat-storefront-debug\`** (\`skills/revcat-storefront-debug/SKILL.md\`)

Triggers on "0 packages", "no packages", "SDK not seeing", "test store", "products not in offering", "offering not working", "fetchOfferings empty", etc.

Walks the 7-step diagnostic flow:

1. Confirm the offering is current
2. Packages attached to the offering
3. Products attached to each package
4. Each product bound to a Store app entry
5. (App Store / Play) push-to-store
6. (Test Store) **prices set in dashboard UI** — the most-missed gotcha
7. Verify what the SDK will receive via \`/v1/subscribers/{id}/offerings\` (curl fallback)

**Updated: \`revcat-troubleshooting\`**

Added three sections:
- **Test Store quirks** — explicitly calls out the dashboard-only price requirement
- **v1-only endpoints** — names the endpoints worth knowing (\`/v1/subscribers/{id}/offerings\` for SDK preview), shows the curl pattern with the public key, points at the new storefront-debug skill for the full flow
- **Dashboard-only operations** — Test Store prices, StoreKit config export, webhook signing-secret rotation

Broadened the description triggers to include "command not supported", "atob error", "endpoint missing".

**Updated: \`revcat-commands\`**

- Broadened description triggers ("which revcat command", "is there a revcat for", "what flags does revcat <subcommand> take") so this skill loads on flag-discovery / command-discovery questions, not just "construct a command"
- Added explicit note: flags are scoped to the subcommand. The failed session assumed \`--app-id\` was universal; it's not on \`packages list\` (which takes \`--offering\`)

## What this PR does NOT fix (separate issues to file)

These are real CLI gaps from the same session that need code changes, not just skill updates:

1. \`revcat <resource> view --output json\` returns fewer fields than the v2 API. Either the CLI should return the full body, or the docs should call out the curated subset.
2. No \`revcat doctor offering <id>\` or \`revcat offerings preview --as-subscriber\` command. Would have closed the loop in 5 seconds instead of 30 minutes.
3. \`revcat packages products <pkg>\` returns empty \`display_name\`. Display name lives on the product, not the binding — either include it via join, or document the v2 quirk.

## Test plan
- [ ] Skill markdown renders cleanly (no broken frontmatter, no rogue fence chars)
- [ ] Triggers from \`revcat-storefront-debug\` pull the right skill on a test prompt like "the SDK is seeing 0 packages from my offering"
- [ ] Triggers from updated \`revcat-troubleshooting\` description fire on Test Store / v1 questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->