### PR TITLE
Surface display_name in `packages products` output

### DIFF
--- a/commands/packages/packages.go
+++ b/commands/packages/packages.go
@@ -244,10 +244,19 @@ func init() {
 	deleteCmd.Flags().BoolVarP(&deleteConfirm, "confirm", "y", false, "Skip the prompt")
 }
 
+var productsNoEnrich bool
+
 var productsCmd = &cobra.Command{
 	Use:   "products <id>",
 	Short: "List products attached to a package",
-	Args:  cobra.ExactArgs(1),
+	Long: `List products attached to a package.
+
+The v2 ` + "`GET /packages/{id}/products`" + ` endpoint returns binding
+metadata only - display_name is not part of the join. By default revcat
+follows up with a per-product GET to fill in display_name (cached so each
+product is only fetched once per call). Pass --no-enrich to skip that and
+return the lean v2 response verbatim.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, _, err := cliutil.Client(cmd)
 		if err != nil {
@@ -259,12 +268,83 @@ var productsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if !productsNoEnrich {
+			prods, err = enrichProducts(ctx, client.GetProduct, prods)
+			if err != nil {
+				return err
+			}
+		}
+		if output.IsJSON() {
+			return output.JSON(prods)
+		}
 		rows := make([][]any, 0, len(prods))
 		for _, p := range prods {
 			rows = append(rows, []any{p.ID, p.StoreIdentifier, p.Type, p.DisplayName})
 		}
 		return output.Table([]string{"id", "store_id", "type", "display_name"}, rows)
 	},
+}
+
+// productGetter matches the *api.Client.GetProduct signature so the
+// enrichment helper is testable without a real HTTP client.
+type productGetter func(ctx context.Context, productID string) (*api.Product, error)
+
+// enrichProducts fills in fields the v2 package-products endpoint omits
+// (notably display_name) by calling GetProduct for each product whose
+// display_name is empty. Results are cached per product id so the same
+// product attached to multiple eligibility rows is only fetched once.
+//
+// On a fetch error the partially-filled slice is returned along with the
+// error so callers can choose to continue. Callers that prefer raw v2
+// output should skip enrichment entirely.
+func enrichProducts(ctx context.Context, get productGetter, prods []api.Product) ([]api.Product, error) {
+	cache := make(map[string]*api.Product, len(prods))
+	out := make([]api.Product, len(prods))
+	copy(out, prods)
+	for i := range out {
+		if out[i].DisplayName != "" || out[i].ID == "" {
+			continue
+		}
+		full, ok := cache[out[i].ID]
+		if !ok {
+			fetched, err := get(ctx, out[i].ID)
+			if err != nil {
+				return out, err
+			}
+			full = fetched
+			cache[out[i].ID] = full
+		}
+		mergeProduct(&out[i], full)
+	}
+	return out, nil
+}
+
+// mergeProduct copies fields from src onto dst when dst's value is the
+// zero value for that field. This preserves any binding-specific fields
+// the package-products endpoint may have set while filling in the gaps.
+func mergeProduct(dst, src *api.Product) {
+	if src == nil {
+		return
+	}
+	if dst.DisplayName == "" {
+		dst.DisplayName = src.DisplayName
+	}
+	if dst.StoreIdentifier == "" {
+		dst.StoreIdentifier = src.StoreIdentifier
+	}
+	if dst.Type == "" {
+		dst.Type = src.Type
+	}
+	if dst.AppID == "" {
+		dst.AppID = src.AppID
+	}
+	if dst.CreatedAt == 0 {
+		dst.CreatedAt = src.CreatedAt
+	}
+}
+
+func init() {
+	productsCmd.Flags().BoolVar(&productsNoEnrich, "no-enrich", false, "Skip per-product GETs that fill in display_name; return the lean v2 response")
 }
 
 var attachEligibility string

--- a/commands/packages/packages_test.go
+++ b/commands/packages/packages_test.go
@@ -1,0 +1,103 @@
+package packages
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/akshitkrnagpal/revcat/internal/api"
+)
+
+// TestEnrichProductsFillsDisplayName covers the case A scenario: the v2
+// package-products endpoint returns binding metadata with an empty
+// display_name. Enrichment must populate it from GetProduct.
+func TestEnrichProductsFillsDisplayName(t *testing.T) {
+	in := []api.Product{
+		{ID: "prod_a", StoreIdentifier: "monthly.sub"},
+	}
+	get := func(_ context.Context, id string) (*api.Product, error) {
+		if id != "prod_a" {
+			t.Fatalf("unexpected product fetch: %s", id)
+		}
+		return &api.Product{ID: id, DisplayName: "Premium Monthly", AppID: "app_x"}, nil
+	}
+	out, err := enrichProducts(context.Background(), get, in)
+	if err != nil {
+		t.Fatalf("enrichProducts: %v", err)
+	}
+	if got := out[0].DisplayName; got != "Premium Monthly" {
+		t.Fatalf("display_name: got %q want %q", got, "Premium Monthly")
+	}
+	if got := out[0].StoreIdentifier; got != "monthly.sub" {
+		t.Fatalf("store_identifier: got %q want %q", got, "monthly.sub")
+	}
+	if got := out[0].AppID; got != "app_x" {
+		t.Fatalf("app_id: got %q want %q", got, "app_x")
+	}
+}
+
+// TestEnrichProductsCachesByID asserts that a product appearing twice
+// (e.g. attached with different eligibility criteria) is only fetched
+// once. Without caching, the package-products endpoint fan-out is N+1
+// against the catalog size.
+func TestEnrichProductsCachesByID(t *testing.T) {
+	in := []api.Product{
+		{ID: "prod_a"},
+		{ID: "prod_a"},
+		{ID: "prod_b"},
+	}
+	calls := map[string]int{}
+	get := func(_ context.Context, id string) (*api.Product, error) {
+		calls[id]++
+		return &api.Product{ID: id, DisplayName: id + "-name"}, nil
+	}
+	out, err := enrichProducts(context.Background(), get, in)
+	if err != nil {
+		t.Fatalf("enrichProducts: %v", err)
+	}
+	if calls["prod_a"] != 1 {
+		t.Fatalf("prod_a fetched %d times, want 1", calls["prod_a"])
+	}
+	if calls["prod_b"] != 1 {
+		t.Fatalf("prod_b fetched %d times, want 1", calls["prod_b"])
+	}
+	for i, p := range out {
+		if p.DisplayName == "" {
+			t.Fatalf("row %d: display_name empty", i)
+		}
+	}
+}
+
+// TestEnrichProductsSkipsWhenAlreadySet keeps the helper a no-op when
+// the v2 endpoint does happen to return display_name (case B). No
+// network calls should fire in that case.
+func TestEnrichProductsSkipsWhenAlreadySet(t *testing.T) {
+	in := []api.Product{
+		{ID: "prod_a", DisplayName: "Already Set"},
+	}
+	get := func(_ context.Context, id string) (*api.Product, error) {
+		t.Fatalf("unexpected fetch for %s when display_name was already set", id)
+		return nil, nil
+	}
+	out, err := enrichProducts(context.Background(), get, in)
+	if err != nil {
+		t.Fatalf("enrichProducts: %v", err)
+	}
+	if out[0].DisplayName != "Already Set" {
+		t.Fatalf("display_name overwritten: got %q", out[0].DisplayName)
+	}
+}
+
+// TestEnrichProductsPropagatesError ensures fetch failures bubble up so
+// the command can decide whether to surface them or fall back.
+func TestEnrichProductsPropagatesError(t *testing.T) {
+	in := []api.Product{{ID: "prod_a"}}
+	want := errors.New("boom")
+	get := func(_ context.Context, _ string) (*api.Product, error) {
+		return nil, want
+	}
+	_, err := enrichProducts(context.Background(), get, in)
+	if !errors.Is(err, want) {
+		t.Fatalf("got %v, want %v", err, want)
+	}
+}


### PR DESCRIPTION
Closes #6.

## Diagnosis (case A)

The v2 `GET /projects/{project_id}/packages/{package_id}/products` endpoint returns binding metadata only - `display_name` is not part of the join. revcat's `api.Product` struct already carries the right JSON tag (`json:"display_name"`), and there is no field-stripping in the read path: `paginate[Product]` unmarshals the v2 response verbatim. The empty value can therefore only come from the v2 endpoint itself.

This is distinct from #4 (the `view` commands curating fields). #4's fix would not resolve this issue on its own - even a verbatim-passthrough JSON would still show `display_name: ""` because the field is absent in the upstream response.

## Fix

Enrich the response by following up with `GET /products/{id}` for each row, cached per product id so the same product attached with multiple eligibility criteria is only fetched once.

- Default: enrichment on. `display_name` is the single most useful field on this command and the round-trip cost is acceptable for a debug-shaped command.
- Opt-out: `--no-enrich` returns the lean v2 response verbatim.
- Also switches the JSON path to emit the full `Product` struct rather than the four-column subset `Table` was projecting (`id`, `store_id`, `type`, `display_name`). Aligns with the spirit of #4. Table output is unchanged.

The enrichment helper is extracted as a pure function over a `productGetter` interface so it can be unit-tested without an HTTP fixture.

## Tests

Four unit tests in `commands/packages/packages_test.go`:

- `TestEnrichProductsFillsDisplayName` - the case A regression: empty `display_name` on the binding row gets filled from `GetProduct`.
- `TestEnrichProductsCachesByID` - duplicate product ids fetch once, not N times.
- `TestEnrichProductsSkipsWhenAlreadySet` - if v2 ever starts returning `display_name`, no extra calls fire.
- `TestEnrichProductsPropagatesError` - fetch failures bubble up.

`go vet ./...` and `go test ./...` clean.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` clean
- [ ] Smoke against a live RC project: `revcat packages products <pkg_id> --output json --pretty` returns non-empty `display_name`
- [ ] `revcat packages products <pkg_id> --no-enrich --output json --pretty` returns the original (empty `display_name`) response, confirming the flag wires through

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->