### PR TITLE
Add `revcat offerings preview` command

### DIFF
--- a/commands/offerings/preview.go
+++ b/commands/offerings/preview.go
@@ -1,0 +1,220 @@
+package offerings
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/akshitkrnagpal/revcat/internal/api"
+	"github.com/akshitkrnagpal/revcat/internal/cliutil"
+	"github.com/akshitkrnagpal/revcat/internal/output"
+)
+
+var (
+	previewAs       string
+	previewPlatform string
+	previewAppID    string
+)
+
+var previewCmd = &cobra.Command{
+	Use:   "preview [<offering_id>]",
+	Short: "Show what the SDK will receive from /v1/subscribers/{user}/offerings",
+	Long: `Hit the v1 SDK-facing endpoint that ` + "`Purchases.getOfferings()`" + ` calls and
+render the response. Useful when the dashboard looks healthy but the SDK
+reports zero packages.
+
+Auth is auto-handled: revcat fetches the public SDK key for the project's
+app on the chosen platform and sends it as the bearer. ` + "`--as`" + ` defaults to a
+synthetic user id (` + "`revcat_preview_<unix_ms>`" + `) so you don't have to think
+about it.
+
+Pass an optional <offering_id> to filter the rendered output to a single
+offering (the request still fetches all offerings; v1 has no per-offering
+endpoint).`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, _, err := cliutil.Client(cmd)
+		if err != nil {
+			return err
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+		defer cancel()
+
+		platform := strings.ToLower(strings.TrimSpace(previewPlatform))
+		if platform == "" {
+			platform = "ios"
+		}
+		if !validPlatform(platform) {
+			return fmt.Errorf("unsupported --platform %q (want ios|android|web)", platform)
+		}
+
+		appID := previewAppID
+		if appID == "" {
+			id, err := pickAppForPlatform(ctx, client, platform)
+			if err != nil {
+				return err
+			}
+			appID = id
+		}
+
+		key, err := pickPublicKey(ctx, client, appID)
+		if err != nil {
+			return err
+		}
+
+		userID := previewAs
+		if userID == "" {
+			userID = fmt.Sprintf("revcat_preview_%d", time.Now().UnixMilli())
+		}
+
+		resp, err := client.PreviewOfferings(ctx, userID, key, headerPlatform(platform))
+		if err != nil {
+			return err
+		}
+
+		if len(args) == 1 && args[0] != "" {
+			filtered := make([]api.PreviewOffering, 0, 1)
+			for _, o := range resp.Offerings {
+				if o.Identifier == args[0] {
+					filtered = append(filtered, o)
+				}
+			}
+			resp.Offerings = filtered
+		}
+
+		if output.IsJSON() {
+			return output.JSON(resp)
+		}
+
+		output.Info("user: %s   platform: %s   app: %s", userID, platform, appID)
+		output.Info("current_offering_id: %s", cliutil.Dash(resp.CurrentOfferingID))
+
+		if len(resp.Offerings) == 0 {
+			output.Warn("no offerings returned")
+			return nil
+		}
+
+		header := [][]any{}
+		for _, o := range resp.Offerings {
+			cur := ""
+			if o.Identifier == resp.CurrentOfferingID {
+				cur = "*"
+			}
+			header = append(header, []any{cur, o.Identifier, len(o.Packages)})
+		}
+		if err := output.Table([]string{"", "offering", "packages"}, header); err != nil {
+			return err
+		}
+
+		for _, o := range resp.Offerings {
+			if len(o.Packages) == 0 {
+				continue
+			}
+			fmt.Fprintln(cmd.OutOrStdout())
+			output.Info("packages in %q:", o.Identifier)
+			rows := make([][]any, 0, len(o.Packages))
+			for _, p := range o.Packages {
+				rows = append(rows, []any{p.Identifier, cliutil.Dash(p.PlatformProductIdentifier)})
+			}
+			if err := output.Table([]string{"identifier", "platform_product_identifier"}, rows); err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	previewCmd.Flags().StringVar(&previewAs, "as", "", "User id to query as (default: revcat_preview_<unix_ms>)")
+	previewCmd.Flags().StringVar(&previewPlatform, "platform", "ios", "Storefront platform to preview (ios|android|web)")
+	previewCmd.Flags().StringVar(&previewAppID, "app-id", "", "App id to derive the public SDK key from (default: auto-detect)")
+	Cmd.AddCommand(previewCmd)
+}
+
+func validPlatform(p string) bool {
+	switch p {
+	case "ios", "android", "web":
+		return true
+	}
+	return false
+}
+
+// headerPlatform returns the value to send in the X-Platform header. The v1
+// API accepts the SDK platform identifiers; we mirror what the official
+// SDKs send.
+func headerPlatform(p string) string {
+	switch p {
+	case "ios":
+		return "iOS"
+	case "android":
+		return "android"
+	case "web":
+		return "web"
+	}
+	return p
+}
+
+// appTypesFor maps a CLI --platform value to the set of v2 App.Type values
+// that count as that storefront. iOS covers App Store + Mac App Store; web
+// covers Stripe + RC web billing.
+func appTypesFor(platform string) []string {
+	switch platform {
+	case "ios":
+		return []string{"app_store", "mac_app_store"}
+	case "android":
+		return []string{"play_store", "amazon"}
+	case "web":
+		return []string{"stripe", "rc_billing", "web_billing"}
+	}
+	return nil
+}
+
+// pickAppForPlatform finds the single app in the active project whose type
+// matches the requested platform. If 0 or >1 apps match, we surface the
+// list and ask the user to pass --app-id explicitly.
+func pickAppForPlatform(ctx context.Context, client *api.Client, platform string) (string, error) {
+	apps, err := client.ListApps(ctx)
+	if err != nil {
+		return "", err
+	}
+	wanted := appTypesFor(platform)
+	matches := make([]api.App, 0, 2)
+	for _, a := range apps {
+		for _, t := range wanted {
+			if a.Type == t {
+				matches = append(matches, a)
+				break
+			}
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0].ID, nil
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no app in this project matches --platform %s; pass --app-id explicitly (run `revcat apps list`)", platform)
+	}
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		names = append(names, fmt.Sprintf("%s (%s, %s)", m.ID, m.Name, m.Type))
+	}
+	return "", fmt.Errorf("multiple apps match --platform %s, pass --app-id explicitly:\n  - %s", platform, strings.Join(names, "\n  - "))
+}
+
+// pickPublicKey returns the first public SDK key for the given app. RC
+// projects usually expose one production key per app; if there are
+// multiple, we take the first listed (callers can pass --app-id to scope).
+func pickPublicKey(ctx context.Context, client *api.Client, appID string) (string, error) {
+	keys, err := client.ListPublicAPIKeys(ctx, appID)
+	if err != nil {
+		return "", fmt.Errorf("fetch public keys for app %s: %w", appID, err)
+	}
+	for _, k := range keys {
+		if k.Key != "" {
+			return k.Key, nil
+		}
+	}
+	return "", fmt.Errorf("app %s has no public SDK keys; create one in the RevenueCat dashboard", appID)
+}

--- a/internal/api/offerings_preview.go
+++ b/internal/api/offerings_preview.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// V1BaseURL is the legacy v1 REST root used by the SDK-facing endpoints
+// (subscriber state, offerings preview). Public SDK keys talk to v1, not v2.
+const V1BaseURL = "https://api.revenuecat.com/v1"
+
+// PreviewOffering mirrors the v1 `/offerings` shape returned to the SDK.
+// Fields are the SDK-facing identifiers, not v2 internal ids.
+type PreviewOffering struct {
+	Identifier  string           `json:"identifier"`
+	Description string           `json:"description,omitempty"`
+	Packages    []PreviewPackage `json:"packages"`
+	Metadata    map[string]any   `json:"metadata,omitempty"`
+}
+
+// PreviewPackage is a single SDK-facing package as it appears in the v1
+// offerings payload.
+type PreviewPackage struct {
+	Identifier                string `json:"identifier"`
+	PlatformProductIdentifier string `json:"platform_product_identifier"`
+}
+
+// PreviewOfferingsResponse is the full body returned by GET
+// /v1/subscribers/{user_id}/offerings.
+type PreviewOfferingsResponse struct {
+	CurrentOfferingID string            `json:"current_offering_id"`
+	Offerings         []PreviewOffering `json:"offerings"`
+}
+
+// PreviewOfferings hits the v1 SDK-facing offerings endpoint with the given
+// public SDK key (Bearer) and X-Platform header. This is the same payload
+// the on-device SDK receives from `Purchases.getOfferings()`, so it is the
+// source of truth when debugging "SDK sees zero packages" symptoms.
+//
+// publicSDKKey must be a public key (one of the keys returned by
+// `revcat apps public-keys <app_id>`), NOT the v2 secret key. platform is
+// sent verbatim in the X-Platform header (e.g. "iOS", "android", "web").
+func (c *Client) PreviewOfferings(ctx context.Context, userID, publicSDKKey, platform string) (*PreviewOfferingsResponse, error) {
+	if userID == "" {
+		return nil, fmt.Errorf("preview offerings: user id required")
+	}
+	if publicSDKKey == "" {
+		return nil, fmt.Errorf("preview offerings: public SDK key required")
+	}
+	if platform == "" {
+		return nil, fmt.Errorf("preview offerings: platform required")
+	}
+	path := "/subscribers/" + url.PathEscape(userID) + "/offerings"
+	headers := map[string]string{"X-Platform": platform}
+	var out PreviewOfferingsResponse
+	if err := c.doV1Bearer(ctx, "GET", path, publicSDKKey, headers, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// doV1Bearer performs a single request against the v1 base URL with a
+// caller-supplied bearer token (typically a public SDK key) instead of the
+// client's stored v2 secret. No retries: v1 SDK endpoints are read-only and
+// callers can re-run trivially.
+func (c *Client) doV1Bearer(ctx context.Context, method, path, bearer string, extraHeaders map[string]string, out any) error {
+	base := V1BaseURL
+	if env := strings.TrimSpace(os.Getenv("REVCAT_V1_BASE_URL")); env != "" {
+		base = env
+	}
+	reqURL := base + path
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", userAgent+"/"+c.version)
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+
+	c.logRequest(req, nil)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	c.logResponse(resp, respBody)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return decodeError(resp.StatusCode, resp.Status, respBody)
+	}
+	if out == nil || len(respBody) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}

--- a/internal/api/offerings_preview_test.go
+++ b/internal/api/offerings_preview_test.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestPreviewOfferings_RequestShape(t *testing.T) {
+	cases := []struct {
+		name         string
+		userID       string
+		platform     string
+		wantPath     string
+		wantPlatform string
+	}{
+		{
+			name:         "ios simple user id",
+			userID:       "revcat_preview_123",
+			platform:     "iOS",
+			wantPath:     "/subscribers/revcat_preview_123/offerings",
+			wantPlatform: "iOS",
+		},
+		{
+			name:         "android with $ in user id is escaped",
+			userID:       "user/with spaces",
+			platform:     "android",
+			wantPath:     "/subscribers/user%2Fwith%20spaces/offerings",
+			wantPlatform: "android",
+		},
+		{
+			name:         "web platform",
+			userID:       "abc",
+			platform:     "web",
+			wantPath:     "/subscribers/abc/offerings",
+			wantPlatform: "web",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath, gotAuth, gotPlatform string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotAuth = r.Header.Get("Authorization")
+				gotPlatform = r.Header.Get("X-Platform")
+				_ = json.NewEncoder(w).Encode(PreviewOfferingsResponse{
+					CurrentOfferingID: "default",
+					Offerings: []PreviewOffering{
+						{Identifier: "default", Packages: []PreviewPackage{
+							{Identifier: "$rc_monthly", PlatformProductIdentifier: "rc_pro_monthly"},
+						}},
+					},
+				})
+			}))
+			defer srv.Close()
+			t.Setenv("REVCAT_V1_BASE_URL", srv.URL)
+
+			c := New(Options{SecretKey: "ignored", Version: "test"})
+			resp, err := c.PreviewOfferings(context.Background(), tc.userID, "pk_test_abc123", tc.platform)
+			if err != nil {
+				t.Fatalf("PreviewOfferings: %v", err)
+			}
+			// Compare decoded path: httptest already decodes r.URL.Path, so compare against decoded form.
+			decodedWant, _ := url.PathUnescape(tc.wantPath)
+			if gotPath != decodedWant {
+				t.Errorf("path: want %q, got %q", decodedWant, gotPath)
+			}
+			if gotAuth != "Bearer pk_test_abc123" {
+				t.Errorf("auth: want Bearer pk_test_abc123, got %q", gotAuth)
+			}
+			if gotPlatform != tc.wantPlatform {
+				t.Errorf("X-Platform: want %q, got %q", tc.wantPlatform, gotPlatform)
+			}
+			if resp.CurrentOfferingID != "default" {
+				t.Errorf("current_offering_id: want default, got %q", resp.CurrentOfferingID)
+			}
+			if len(resp.Offerings) != 1 || len(resp.Offerings[0].Packages) != 1 {
+				t.Fatalf("unexpected response shape: %+v", resp)
+			}
+			if resp.Offerings[0].Packages[0].Identifier != "$rc_monthly" {
+				t.Errorf("package id: want $rc_monthly, got %q", resp.Offerings[0].Packages[0].Identifier)
+			}
+		})
+	}
+}
+
+func TestPreviewOfferings_Validation(t *testing.T) {
+	c := New(Options{SecretKey: "k", Version: "test"})
+	if _, err := c.PreviewOfferings(context.Background(), "", "pk", "ios"); err == nil {
+		t.Error("want error for empty user id")
+	}
+	if _, err := c.PreviewOfferings(context.Background(), "u", "", "ios"); err == nil {
+		t.Error("want error for empty key")
+	}
+	if _, err := c.PreviewOfferings(context.Background(), "u", "pk", ""); err == nil {
+		t.Error("want error for empty platform")
+	}
+}
+
+func TestPreviewOfferings_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"invalid api key"}`))
+	}))
+	defer srv.Close()
+	t.Setenv("REVCAT_V1_BASE_URL", srv.URL)
+
+	c := New(Options{SecretKey: "k", Version: "test"})
+	_, err := c.PreviewOfferings(context.Background(), "u", "bad_key", "iOS")
+	if err == nil {
+		t.Fatal("want error for 401")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want APIError, got %T: %v", err, err)
+	}
+	if apiErr.Status != http.StatusUnauthorized {
+		t.Errorf("status: want 401, got %d", apiErr.Status)
+	}
+	if !strings.Contains(apiErr.Message, "invalid api key") {
+		t.Errorf("message: want to contain 'invalid api key', got %q", apiErr.Message)
+	}
+}

--- a/skills/revcat-storefront-debug/SKILL.md
+++ b/skills/revcat-storefront-debug/SKILL.md
@@ -94,19 +94,25 @@ This is the v2 endpoint that triggers RC's sync to the underlying store. Must be
 
 Without prices, `/v1/subscribers/{user_id}/offerings` returns the offering with `packages: []`, which is exactly the "SDK sees 0 packages" symptom. revcat cannot fix this from the CLI.
 
-### 7. Verify what the SDK will actually receive (v1 endpoint, curl fallback)
-
-revcat doesn't wrap v1, so this is the one place curl is the right tool:
+### 7. Verify what the SDK will actually receive (v1 offerings preview)
 
 ```sh
-# Use the PUBLIC SDK key (one of the test or production public keys), not the
-# v2 secret key. Get it via:
-#   revcat apps public-keys <app_id>
-TEST_KEY="<public_key>"
-curl -s "https://api.revenuecat.com/v1/subscribers/<user_id>/offerings" \
-    -H "Authorization: Bearer $TEST_KEY" \
-    -H "X-Platform: iOS"
+# Default platform is iOS, default user id is a synthetic revcat_preview_<unix_ms>.
+revcat offerings preview
+
+# Other platforms / a specific user / one offering:
+revcat offerings preview --platform android
+revcat offerings preview --as cust_abc123
+revcat offerings preview default --platform ios
+
+# Raw v1 JSON shape:
+revcat offerings preview --output json
 ```
+
+`revcat offerings preview` calls the v1 SDK-facing endpoint
+(`/v1/subscribers/{user_id}/offerings`) using the public SDK key for the
+project's app on the chosen platform. This is the same payload the
+on-device SDK sees from `Purchases.getOfferings()`.
 
 A healthy response looks like:
 
@@ -137,10 +143,9 @@ If `packages` is empty here, the SDK will also see empty. The cause is upstream 
 
 ## Where revcat does NOT cover the flow
 
-revcat wraps the v2 RC API. It does not cover:
+revcat primarily wraps the v2 RC API (with one v1 read in `offerings preview`). It does not cover:
 
 - **Test Store price setting** (dashboard UI only, no v2 endpoint exists)
-- **Per-subscriber offering preview** (v1 endpoint, use curl as shown in step 7)
 - **Sync status to App Store Connect / Play Console** beyond `push-to-store`
 
-If the user reaches for curl on any v2 endpoint, that's a revcat bug worth filing. If they reach for curl on a v1 endpoint or a dashboard-only operation, that's expected and this skill should call it out.
+If the user reaches for curl on any v2 endpoint, that's a revcat bug worth filing. If they reach for curl on a dashboard-only operation, that's expected and this skill should call it out.


### PR DESCRIPTION
Closes #5.

## Summary

Adds `revcat offerings preview [<offering_id>] [--as <user>] [--platform ios|android|web] [--app-id <id>]`. It calls the v1 SDK-facing endpoint `GET /v1/subscribers/{user_id}/offerings` with the public SDK key as the bearer and renders the response — i.e. the exact payload `Purchases.getOfferings()` would receive on-device.

This is the canonical "step 7" in the storefront-debug skill (was a curl fallback; now a first-class command).

## Defaults so the common case is one command

- `--as` defaults to a synthetic `revcat_preview_<unix_ms>` user id
- `--platform` defaults to `ios`
- `--app-id` is auto-detected: if the project has exactly one app matching the platform (`app_store`/`mac_app_store` for iOS, `play_store`/`amazon` for Android, `stripe`/`rc_billing`/`web_billing` for web) it's used. Otherwise revcat surfaces the candidate apps and asks the user to pass `--app-id` explicitly.
- Public SDK key is fetched internally via the existing `ListPublicAPIKeys` plumbing.

## Wiring

- New file `internal/api/offerings_preview.go`: `PreviewOfferings(userID, publicSDKKey, platform)` + a small `doV1Bearer` helper. The base `Client` is keyed to the v2 secret, so v1 needed its own code path with a caller-supplied bearer. `REVCAT_V1_BASE_URL` env override added for tests.
- New file `commands/offerings/preview.go`: cobra wiring, defaults, auto-detect, table render.
- `skills/revcat-storefront-debug/SKILL.md` step 7 now points at the new command instead of the curl fallback.

## Sample TTY output

```
$ revcat offerings preview
user: revcat_preview_1730073412345   platform: ios   app: app1abc
current_offering_id: default
┌───┬──────────┬──────────┐
│   │ offering │ packages │
├───┼──────────┼──────────┤
│ * │ default  │        2 │
│   │ premium  │        1 │
└───┴──────────┴──────────┘

packages in "default":
┌──────────────┬─────────────────────────────┐
│ identifier   │ platform_product_identifier │
├──────────────┼─────────────────────────────┤
│ $rc_monthly  │ com.revcat.pro.monthly      │
│ $rc_annual   │ com.revcat.pro.annual       │
└──────────────┴─────────────────────────────┘
```

## Sample JSON output (`--output json`)

```json
{
  "current_offering_id": "default",
  "offerings": [
    {
      "identifier": "default",
      "packages": [
        { "identifier": "$rc_monthly", "platform_product_identifier": "com.revcat.pro.monthly" },
        { "identifier": "$rc_annual",  "platform_product_identifier": "com.revcat.pro.annual"  }
      ]
    }
  ]
}
```

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` clean (added `internal/api/offerings_preview_test.go` covering URL/header construction, validation, and API error decoding via `httptest`)
- [x] `revcat offerings --help` lists `preview`
- [x] `revcat offerings preview --help` shows flags + help text
- [ ] Manual: run against a real RevenueCat project with `--platform ios` and `--platform android`, confirm response matches what the SDK sees
- [ ] Manual: confirm `--output json` returns the raw v1 response shape unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->