### PR TITLE
Pass through full v2 fields in `view --output json`

### DIFF
--- a/commands/apps/apps.go
+++ b/commands/apps/apps.go
@@ -63,12 +63,12 @@ var viewCmd = &cobra.Command{
 		}
 		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
-		a, err := client.GetApp(ctx, args[0])
+		a, raw, err := client.GetAppRaw(ctx, args[0])
 		if err != nil {
 			return err
 		}
 		if output.IsJSON() {
-			return output.JSON(a)
+			return output.JSON(raw)
 		}
 		bundleOrPkg := a.BundleID
 		bundleLabel := "bundle_id"

--- a/commands/entitlements/entitlements.go
+++ b/commands/entitlements/entitlements.go
@@ -60,12 +60,12 @@ var viewCmd = &cobra.Command{
 		}
 		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
-		e, err := client.GetEntitlement(ctx, args[0])
+		e, raw, err := client.GetEntitlementRaw(ctx, args[0])
 		if err != nil {
 			return err
 		}
 		if output.IsJSON() {
-			return output.JSON(e)
+			return output.JSON(raw)
 		}
 		rows := [][]any{
 			{"id", e.LookupKey},

--- a/commands/offerings/offerings.go
+++ b/commands/offerings/offerings.go
@@ -68,7 +68,19 @@ var viewCmd = &cobra.Command{
 		}
 		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
-		o, err := client.GetOffering(ctx, args[0], viewWithPackages || !output.IsJSON())
+		// JSON path: pass the v2 single-object response through verbatim
+		// so no v2 fields are silently dropped (issue #4). Users who
+		// want packages stitched in can pass --packages on the JSON path,
+		// which falls back to the typed render.
+		withPackages := viewWithPackagesSet(cmd)
+		if output.IsJSON() && !withPackages {
+			_, raw, err := client.GetOfferingRaw(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			return output.JSON(raw)
+		}
+		o, err := client.GetOffering(ctx, args[0], withPackages || !output.IsJSON())
 		if err != nil {
 			return err
 		}
@@ -101,7 +113,22 @@ var viewCmd = &cobra.Command{
 }
 
 func init() {
-	viewCmd.Flags().BoolVar(&viewWithPackages, "packages", true, "Include packages in the rendered card")
+	viewCmd.Flags().BoolVar(&viewWithPackages, "packages", true, "Include packages in the rendered card (table mode). On --output json, pass --packages explicitly to opt into the stitched typed shape; default is the verbatim v2 response.")
+}
+
+// viewWithPackagesSet returns true if --packages was set explicitly OR if
+// we're rendering a TTY table (where the default of true applies). On JSON
+// output the default is treated as false so users get the verbatim v2
+// response unless they explicitly opt in.
+func viewWithPackagesSet(cmd *cobra.Command) bool {
+	f := cmd.Flag("packages")
+	if f != nil && f.Changed {
+		return viewWithPackages
+	}
+	if output.IsJSON() {
+		return false
+	}
+	return viewWithPackages
 }
 
 var (

--- a/commands/packages/packages.go
+++ b/commands/packages/packages.go
@@ -91,12 +91,12 @@ var viewCmd = &cobra.Command{
 		}
 		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
-		p, err := client.GetPackage(ctx, args[0])
+		p, raw, err := client.GetPackageRaw(ctx, args[0])
 		if err != nil {
 			return err
 		}
 		if output.IsJSON() {
-			return output.JSON(p)
+			return output.JSON(raw)
 		}
 		rows := [][]any{
 			{"id", p.ID},

--- a/commands/products/products.go
+++ b/commands/products/products.go
@@ -71,12 +71,12 @@ var viewCmd = &cobra.Command{
 		}
 		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
-		p, err := client.GetProduct(ctx, args[0])
+		p, raw, err := client.GetProductRaw(ctx, args[0])
 		if err != nil {
 			return err
 		}
 		if output.IsJSON() {
-			return output.JSON(p)
+			return output.JSON(raw)
 		}
 		rows := [][]any{
 			{"id", p.ID},

--- a/commands/projects/projects.go
+++ b/commands/projects/projects.go
@@ -70,12 +70,12 @@ var viewCmd = &cobra.Command{
 		}
 		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
-		p, err := client.GetProject(ctx, id)
+		p, raw, err := client.GetProjectRaw(ctx, id)
 		if err != nil {
 			return err
 		}
 		if output.IsJSON() {
-			return output.JSON(p)
+			return output.JSON(raw)
 		}
 		rows := [][]any{
 			{"id", p.ID},

--- a/commands/purchases/purchases.go
+++ b/commands/purchases/purchases.go
@@ -36,12 +36,12 @@ var viewCmd = &cobra.Command{
 		}
 		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
-		p, err := client.GetPurchase(ctx, args[0])
+		p, raw, err := client.GetPurchaseRaw(ctx, args[0])
 		if err != nil {
 			return err
 		}
 		if output.IsJSON() {
-			return output.JSON(p)
+			return output.JSON(raw)
 		}
 		rows := [][]any{
 			{"id", p.ID},

--- a/commands/subscriptions/subscriptions.go
+++ b/commands/subscriptions/subscriptions.go
@@ -37,12 +37,12 @@ var viewCmd = &cobra.Command{
 		}
 		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
-		s, err := client.GetSubscription(ctx, args[0])
+		s, raw, err := client.GetSubscriptionRaw(ctx, args[0])
 		if err != nil {
 			return err
 		}
 		if output.IsJSON() {
-			return output.JSON(s)
+			return output.JSON(raw)
 		}
 		rows := [][]any{
 			{"id", s.ID},

--- a/commands/virtualcurrencies/virtualcurrencies.go
+++ b/commands/virtualcurrencies/virtualcurrencies.go
@@ -62,12 +62,12 @@ var viewCmd = &cobra.Command{
 		}
 		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
-		v, err := client.GetVirtualCurrency(ctx, strings.ToUpper(args[0]))
+		v, raw, err := client.GetVirtualCurrencyRaw(ctx, strings.ToUpper(args[0]))
 		if err != nil {
 			return err
 		}
 		if output.IsJSON() {
-			return output.JSON(v)
+			return output.JSON(raw)
 		}
 		rows := [][]any{
 			{"code", v.Code},

--- a/commands/webhooks/webhooks.go
+++ b/commands/webhooks/webhooks.go
@@ -64,12 +64,12 @@ var viewCmd = &cobra.Command{
 		}
 		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
-		h, err := client.GetWebhook(ctx, args[0])
+		h, raw, err := client.GetWebhookRaw(ctx, args[0])
 		if err != nil {
 			return err
 		}
 		if output.IsJSON() {
-			return output.JSON(h)
+			return output.JSON(raw)
 		}
 		rows := [][]any{
 			{"id", h.ID},

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -88,6 +88,18 @@ func (e *APIError) IsNotFound() bool { return e.Status == http.StatusNotFound }
 // Retries: 429 (respecting Retry-After when present) and 5xx, up to 3
 // attempts with exponential backoff (200ms, 600ms, 1.8s).
 func (c *Client) Do(ctx context.Context, method, path string, body any, out any) error {
+	_, err := c.doRaw(ctx, method, path, body, out)
+	return err
+}
+
+// DoRaw is like Do but also returns the verbatim response body. Used by
+// view commands that want to surface the full v2 response in --output json
+// without dropping fields the typed struct doesn't model.
+func (c *Client) DoRaw(ctx context.Context, method, path string, body any, out any) (json.RawMessage, error) {
+	return c.doRaw(ctx, method, path, body, out)
+}
+
+func (c *Client) doRaw(ctx context.Context, method, path string, body any, out any) (json.RawMessage, error) {
 	url := c.baseURL + path
 
 	var bodyBytes []byte
@@ -95,7 +107,7 @@ func (c *Client) Do(ctx context.Context, method, path string, body any, out any)
 		var err error
 		bodyBytes, err = json.Marshal(body)
 		if err != nil {
-			return fmt.Errorf("encode request: %w", err)
+			return nil, fmt.Errorf("encode request: %w", err)
 		}
 	}
 
@@ -105,7 +117,7 @@ func (c *Client) Do(ctx context.Context, method, path string, body any, out any)
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(bodyBytes))
 		if err != nil {
-			return err
+			return nil, err
 		}
 		req.Header.Set("Authorization", "Bearer "+c.secretKey)
 		req.Header.Set("Accept", "application/json")
@@ -119,7 +131,7 @@ func (c *Client) Do(ctx context.Context, method, path string, body any, out any)
 		resp, err := c.http.Do(req)
 		if err != nil {
 			if attempt == maxAttempts {
-				return fmt.Errorf("request: %w", err)
+				return nil, fmt.Errorf("request: %w", err)
 			}
 			time.Sleep(backoff)
 			backoff *= 3
@@ -132,7 +144,7 @@ func (c *Client) Do(ctx context.Context, method, path string, body any, out any)
 
 		if resp.StatusCode == 429 || resp.StatusCode >= 500 {
 			if attempt == maxAttempts {
-				return decodeError(resp.StatusCode, resp.Status, respBody)
+				return nil, decodeError(resp.StatusCode, resp.Status, respBody)
 			}
 			wait := backoff
 			if ra := resp.Header.Get("Retry-After"); ra != "" {
@@ -146,18 +158,20 @@ func (c *Client) Do(ctx context.Context, method, path string, body any, out any)
 		}
 
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return decodeError(resp.StatusCode, resp.Status, respBody)
+			return nil, decodeError(resp.StatusCode, resp.Status, respBody)
 		}
 
-		if out == nil || len(respBody) == 0 {
-			return nil
+		if len(respBody) == 0 {
+			return nil, nil
 		}
-		if err := json.Unmarshal(respBody, out); err != nil {
-			return fmt.Errorf("decode response: %w", err)
+		if out != nil {
+			if err := json.Unmarshal(respBody, out); err != nil {
+				return nil, fmt.Errorf("decode response: %w", err)
+			}
 		}
-		return nil
+		return json.RawMessage(respBody), nil
 	}
-	return errors.New("exhausted retries")
+	return nil, errors.New("exhausted retries")
 }
 
 func decodeError(status int, statusText string, body []byte) error {

--- a/internal/api/customers.go
+++ b/internal/api/customers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -96,6 +97,21 @@ func (c *Client) GetCustomer(ctx context.Context, customerID string) (*Customer,
 	return &out, nil
 }
 
+// GetCustomerRaw fetches the customer record and returns the verbatim v2
+// response alongside the typed projection.
+func (c *Client) GetCustomerRaw(ctx context.Context, customerID string) (*Customer, json.RawMessage, error) {
+	if err := c.requireProject(); err != nil {
+		return nil, nil, err
+	}
+	var out Customer
+	path := c.projectPath("/customers/" + url.PathEscape(customerID))
+	raw, err := c.DoRaw(ctx, "GET", path, nil, &out)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &out, raw, nil
+}
+
 // ListActiveEntitlements pages through a customer's active entitlements.
 func (c *Client) ListActiveEntitlements(ctx context.Context, customerID string) ([]ActiveEntitlement, error) {
 	return paginate[ActiveEntitlement](ctx, c, c.projectPath("/customers/"+url.PathEscape(customerID)+"/active_entitlements"))
@@ -120,13 +136,105 @@ func (c *Client) ListAliases(ctx context.Context, customerID string) ([]Alias, e
 // CustomerSnapshot is the assembled view rendered by `revcat subscribers info`.
 // Each field is filled by a parallel API call; partial failure is tolerated
 // so a missing endpoint doesn't blank the whole report.
+//
+// The Raw* fields hold the verbatim v2 bytes for each section so JSON
+// output can pass through every field RC returns rather than the curated
+// typed projection. They marshal under the same JSON keys as the typed
+// fields when present (via MarshalJSON) so consumers see one shape.
 type CustomerSnapshot struct {
-	Customer      *Customer            `json:"customer,omitempty"`
-	Entitlements  []ActiveEntitlement  `json:"active_entitlements,omitempty"`
-	Subscriptions []Subscription       `json:"subscriptions,omitempty"`
-	Purchases     []Purchase           `json:"purchases,omitempty"`
-	Aliases       []Alias              `json:"aliases,omitempty"`
+	Customer      *Customer            `json:"-"`
+	Entitlements  []ActiveEntitlement  `json:"-"`
+	Subscriptions []Subscription       `json:"-"`
+	Purchases     []Purchase           `json:"-"`
+	Aliases       []Alias              `json:"-"`
 	Errors        map[string]string    `json:"errors,omitempty"`
+
+	// Raw* hold the verbatim v2 bytes per section; populated on success.
+	RawCustomer      json.RawMessage   `json:"-"`
+	RawEntitlements  []json.RawMessage `json:"-"`
+	RawSubscriptions []json.RawMessage `json:"-"`
+	RawPurchases     []json.RawMessage `json:"-"`
+	RawAliases       []json.RawMessage `json:"-"`
+}
+
+// MarshalJSON renders the snapshot with the raw v2 field set when
+// available, falling back to the typed projection otherwise. This keeps
+// `revcat subscribers info --output json` field-complete relative to the
+// underlying v2 response (issue #4).
+func (s *CustomerSnapshot) MarshalJSON() ([]byte, error) {
+	type rawArr = []json.RawMessage
+	out := struct {
+		Customer      json.RawMessage `json:"customer,omitempty"`
+		Entitlements  rawArr          `json:"active_entitlements,omitempty"`
+		Subscriptions rawArr          `json:"subscriptions,omitempty"`
+		Purchases     rawArr          `json:"purchases,omitempty"`
+		Aliases       rawArr          `json:"aliases,omitempty"`
+		Errors        map[string]string `json:"errors,omitempty"`
+	}{Errors: s.Errors}
+
+	if s.RawCustomer != nil {
+		out.Customer = s.RawCustomer
+	} else if s.Customer != nil {
+		b, err := json.Marshal(s.Customer)
+		if err != nil {
+			return nil, err
+		}
+		out.Customer = b
+	}
+
+	if s.RawEntitlements != nil {
+		out.Entitlements = s.RawEntitlements
+	} else if s.Entitlements != nil {
+		out.Entitlements = make(rawArr, 0, len(s.Entitlements))
+		for i := range s.Entitlements {
+			b, err := json.Marshal(s.Entitlements[i])
+			if err != nil {
+				return nil, err
+			}
+			out.Entitlements = append(out.Entitlements, b)
+		}
+	}
+
+	if s.RawSubscriptions != nil {
+		out.Subscriptions = s.RawSubscriptions
+	} else if s.Subscriptions != nil {
+		out.Subscriptions = make(rawArr, 0, len(s.Subscriptions))
+		for i := range s.Subscriptions {
+			b, err := json.Marshal(s.Subscriptions[i])
+			if err != nil {
+				return nil, err
+			}
+			out.Subscriptions = append(out.Subscriptions, b)
+		}
+	}
+
+	if s.RawPurchases != nil {
+		out.Purchases = s.RawPurchases
+	} else if s.Purchases != nil {
+		out.Purchases = make(rawArr, 0, len(s.Purchases))
+		for i := range s.Purchases {
+			b, err := json.Marshal(s.Purchases[i])
+			if err != nil {
+				return nil, err
+			}
+			out.Purchases = append(out.Purchases, b)
+		}
+	}
+
+	if s.RawAliases != nil {
+		out.Aliases = s.RawAliases
+	} else if s.Aliases != nil {
+		out.Aliases = make(rawArr, 0, len(s.Aliases))
+		for i := range s.Aliases {
+			b, err := json.Marshal(s.Aliases[i])
+			if err != nil {
+				return nil, err
+			}
+			out.Aliases = append(out.Aliases, b)
+		}
+	}
+
+	return json.Marshal(out)
 }
 
 // SnapshotCustomer fans out the per-customer endpoints in parallel and
@@ -154,43 +262,48 @@ func (c *Client) SnapshotCustomer(ctx context.Context, customerID string) (*Cust
 	}
 
 	collect("customer", func() error {
-		v, err := c.GetCustomer(ctx, customerID)
+		v, raw, err := c.GetCustomerRaw(ctx, customerID)
 		if err != nil {
 			return err
 		}
 		snap.Customer = v
+		snap.RawCustomer = raw
 		return nil
 	})
 	collect("entitlements", func() error {
-		v, err := c.ListActiveEntitlements(ctx, customerID)
+		typed, raw, err := paginateBoth[ActiveEntitlement](ctx, c, c.projectPath("/customers/"+url.PathEscape(customerID)+"/active_entitlements"))
 		if err != nil {
 			return err
 		}
-		snap.Entitlements = v
+		snap.Entitlements = typed
+		snap.RawEntitlements = raw
 		return nil
 	})
 	collect("subscriptions", func() error {
-		v, err := c.ListSubscriptions(ctx, customerID)
+		typed, raw, err := paginateBoth[Subscription](ctx, c, c.projectPath("/customers/"+url.PathEscape(customerID)+"/subscriptions"))
 		if err != nil {
 			return err
 		}
-		snap.Subscriptions = v
+		snap.Subscriptions = typed
+		snap.RawSubscriptions = raw
 		return nil
 	})
 	collect("purchases", func() error {
-		v, err := c.ListPurchases(ctx, customerID)
+		typed, raw, err := paginateBoth[Purchase](ctx, c, c.projectPath("/customers/"+url.PathEscape(customerID)+"/purchases"))
 		if err != nil {
 			return err
 		}
-		snap.Purchases = v
+		snap.Purchases = typed
+		snap.RawPurchases = raw
 		return nil
 	})
 	collect("aliases", func() error {
-		v, err := c.ListAliases(ctx, customerID)
+		typed, raw, err := paginateBoth[Alias](ctx, c, c.projectPath("/customers/"+url.PathEscape(customerID)+"/aliases"))
 		if err != nil {
 			return err
 		}
-		snap.Aliases = v
+		snap.Aliases = typed
+		snap.RawAliases = raw
 		return nil
 	})
 
@@ -374,6 +487,35 @@ func paginate[T any](ctx context.Context, c *Client, basePath string) ([]T, erro
 		all = append(all, page.Items...)
 		if page.Next == "" {
 			return all, nil
+		}
+		path = basePath + "?limit=100&starting_after=" + page.Next
+	}
+}
+
+// paginateBoth is paginate with raw item bytes preserved. The typed slice
+// is for table/snapshot rendering, the raw slice keeps every v2 field.
+func paginateBoth[T any](ctx context.Context, c *Client, basePath string) ([]T, []json.RawMessage, error) {
+	typed := []T{}
+	rawAll := []json.RawMessage{}
+	path := basePath + "?limit=100"
+	for {
+		var page struct {
+			Items []json.RawMessage `json:"items"`
+			Next  string            `json:"next_page,omitempty"`
+		}
+		if err := c.Do(ctx, "GET", path, nil, &page); err != nil {
+			return nil, nil, err
+		}
+		for _, item := range page.Items {
+			var v T
+			if err := json.Unmarshal(item, &v); err != nil {
+				return nil, nil, fmt.Errorf("decode list item: %w", err)
+			}
+			typed = append(typed, v)
+			rawAll = append(rawAll, item)
+		}
+		if page.Next == "" {
+			return typed, rawAll, nil
 		}
 		path = basePath + "?limit=100&starting_after=" + page.Next
 	}

--- a/internal/api/entitlements.go
+++ b/internal/api/entitlements.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/url"
 )
 
@@ -61,6 +62,25 @@ func (c *Client) GetEntitlement(ctx context.Context, idOrKey string) (*Entitleme
 		return nil, err
 	}
 	return &out, nil
+}
+
+// GetEntitlementRaw fetches an entitlement and returns the verbatim v2
+// response alongside the typed projection.
+func (c *Client) GetEntitlementRaw(ctx context.Context, idOrKey string) (*Entitlement, json.RawMessage, error) {
+	if err := c.requireProject(); err != nil {
+		return nil, nil, err
+	}
+	id, err := c.ResolveEntitlementID(ctx, idOrKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	var out Entitlement
+	path := c.projectPath("/entitlements/" + url.PathEscape(id))
+	raw, err := c.DoRaw(ctx, "GET", path, nil, &out)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &out, raw, nil
 }
 
 // CreateEntitlement creates a new entitlement.

--- a/internal/api/offerings.go
+++ b/internal/api/offerings.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/url"
 )
 
@@ -85,6 +86,27 @@ func (c *Client) GetOffering(ctx context.Context, idOrKey string, withPackages b
 		out.Packages = pkgs
 	}
 	return &out, nil
+}
+
+// GetOfferingRaw fetches an offering and returns the v2 response verbatim
+// alongside the typed projection. withPackages is intentionally omitted
+// here - the raw response is the v2 single-object body, no client-side
+// stitching applied.
+func (c *Client) GetOfferingRaw(ctx context.Context, idOrKey string) (*Offering, json.RawMessage, error) {
+	if err := c.requireProject(); err != nil {
+		return nil, nil, err
+	}
+	id, err := c.ResolveOfferingID(ctx, idOrKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	var out Offering
+	path := c.projectPath("/offerings/" + url.PathEscape(id))
+	raw, err := c.DoRaw(ctx, "GET", path, nil, &out)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &out, raw, nil
 }
 
 // ListPackages pages through the packages in an offering. Accepts either
@@ -219,6 +241,19 @@ func (c *Client) GetPackage(ctx context.Context, packageID string) (*Package, er
 		return nil, err
 	}
 	return &p, nil
+}
+
+// GetPackageRaw fetches a package and returns the verbatim v2 response.
+func (c *Client) GetPackageRaw(ctx context.Context, packageID string) (*Package, json.RawMessage, error) {
+	if err := c.requireProject(); err != nil {
+		return nil, nil, err
+	}
+	var p Package
+	raw, err := c.DoRaw(ctx, "GET", c.projectPath("/packages/"+url.PathEscape(packageID)), nil, &p)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &p, raw, nil
 }
 
 // CreatePackage creates a package under an offering. The v2 endpoint is

--- a/internal/api/paywalls.go
+++ b/internal/api/paywalls.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/url"
 )
 
@@ -89,6 +90,19 @@ func (c *Client) GetWebhook(ctx context.Context, id string) (*Webhook, error) {
 	return &w, nil
 }
 
+// GetWebhookRaw fetches one webhook and returns the verbatim v2 response.
+func (c *Client) GetWebhookRaw(ctx context.Context, id string) (*Webhook, json.RawMessage, error) {
+	if err := c.requireProject(); err != nil {
+		return nil, nil, err
+	}
+	var w Webhook
+	raw, err := c.DoRaw(ctx, "GET", c.projectPath("/integrations/webhooks/"+url.PathEscape(id)), nil, &w)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &w, raw, nil
+}
+
 // CreateWebhook creates a webhook integration.
 func (c *Client) CreateWebhook(ctx context.Context, body map[string]any) (*Webhook, error) {
 	if err := c.requireProject(); err != nil {
@@ -151,6 +165,19 @@ func (c *Client) GetVirtualCurrency(ctx context.Context, idOrKey string) (*Virtu
 		return nil, err
 	}
 	return &v, nil
+}
+
+// GetVirtualCurrencyRaw fetches a VC and returns the verbatim v2 response.
+func (c *Client) GetVirtualCurrencyRaw(ctx context.Context, idOrKey string) (*VirtualCurrency, json.RawMessage, error) {
+	if err := c.requireProject(); err != nil {
+		return nil, nil, err
+	}
+	var v VirtualCurrency
+	raw, err := c.DoRaw(ctx, "GET", c.projectPath("/virtual_currencies/"+url.PathEscape(idOrKey)), nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &v, raw, nil
 }
 
 // CreateVirtualCurrency creates a VC.

--- a/internal/api/products.go
+++ b/internal/api/products.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/url"
 )
 
@@ -36,6 +37,22 @@ func (c *Client) GetProduct(ctx context.Context, productID string) (*Product, er
 		return nil, err
 	}
 	return &p, nil
+}
+
+// GetProductRaw fetches one product by id and returns the response body
+// verbatim alongside the typed projection. The raw bytes let view commands
+// surface every v2 field in --output json without re-modeling the schema;
+// the typed struct stays around so the table renderer can pick its columns.
+func (c *Client) GetProductRaw(ctx context.Context, productID string) (*Product, json.RawMessage, error) {
+	if err := c.requireProject(); err != nil {
+		return nil, nil, err
+	}
+	var p Product
+	raw, err := c.DoRaw(ctx, "GET", c.projectPath("/products/"+url.PathEscape(productID)), nil, &p)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &p, raw, nil
 }
 
 // CreateProduct creates a product. Body is a free-form map because the

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -1,6 +1,9 @@
 package api
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+)
 
 // Project is the v2 representation of a RevenueCat project. Trimmed to the
 // fields revcat surfaces; extend as commands need more.
@@ -48,6 +51,36 @@ func (c *Client) GetProject(ctx context.Context, id string) (*Project, error) {
 	return nil, &APIError{Status: 404, StatusText: "Not Found", Message: "no project with id " + id + " accessible to this key"}
 }
 
+// GetProjectRaw fetches a project and returns the verbatim list-item bytes
+// alongside the typed projection. v2 has no per-id project endpoint, so
+// this iterates list pages and matches the wanted id - the raw bytes are
+// the matching item exactly as v2 returned it.
+func (c *Client) GetProjectRaw(ctx context.Context, id string) (*Project, json.RawMessage, error) {
+	path := "/projects?limit=100"
+	for {
+		var page struct {
+			Items []json.RawMessage `json:"items"`
+			Next  string            `json:"next_page,omitempty"`
+		}
+		if err := c.Do(ctx, "GET", path, nil, &page); err != nil {
+			return nil, nil, err
+		}
+		for _, raw := range page.Items {
+			var p Project
+			if err := json.Unmarshal(raw, &p); err != nil {
+				return nil, nil, err
+			}
+			if p.ID == id {
+				return &p, raw, nil
+			}
+		}
+		if page.Next == "" {
+			return nil, nil, &APIError{Status: 404, StatusText: "Not Found", Message: "no project with id " + id + " accessible to this key"}
+		}
+		path = "/projects?limit=100&starting_after=" + page.Next
+	}
+}
+
 // App is a per-platform app inside a project (one per bundle id / package).
 type App struct {
 	ID          string `json:"id"`
@@ -84,6 +117,19 @@ func (c *Client) GetApp(ctx context.Context, appID string) (*App, error) {
 		return nil, err
 	}
 	return &a, nil
+}
+
+// GetAppRaw fetches an app and returns the verbatim v2 response.
+func (c *Client) GetAppRaw(ctx context.Context, appID string) (*App, json.RawMessage, error) {
+	if err := c.requireProject(); err != nil {
+		return nil, nil, err
+	}
+	var a App
+	raw, err := c.DoRaw(ctx, "GET", c.projectPath("/apps/"+appID), nil, &a)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &a, raw, nil
 }
 
 // ListPublicAPIKeys returns the SDK-side keys for an app.

--- a/internal/api/raw_test.go
+++ b/internal/api/raw_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGetProductRaw_PreservesAllV2Fields is the regression test for issue
+// #4. The typed Product struct only models a handful of fields, but
+// `revcat products view --output json` must surface every key the v2 API
+// returned. GetProductRaw promises to return the verbatim response.
+func TestGetProductRaw_PreservesAllV2Fields(t *testing.T) {
+	v2Body := `{
+		"id": "prod8af0c2ae8c",
+		"store_identifier": "app.monthly",
+		"type": "subscription",
+		"display_name": "Monthly",
+		"app_id": "app_abc",
+		"created_at": 1700000000,
+		"future_field_revcat_doesnt_model": "still here",
+		"nested": {"deep": {"keep": true}}
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/products/prod8af0c2ae8c") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(v2Body))
+	}))
+	defer srv.Close()
+
+	c := New(Options{
+		SecretKey: "sk_test",
+		ProjectID: "proj_xyz",
+		BaseURL:   srv.URL,
+	})
+
+	p, raw, err := c.GetProductRaw(context.Background(), "prod8af0c2ae8c")
+	if err != nil {
+		t.Fatalf("GetProductRaw: %v", err)
+	}
+
+	// Typed projection still works for table render.
+	if p.ID != "prod8af0c2ae8c" || p.AppID != "app_abc" {
+		t.Errorf("typed projection lost fields: %+v", p)
+	}
+
+	// Raw bytes must round-trip into a map and contain every v2 key,
+	// including ones the typed struct doesn't model.
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	for _, k := range []string{
+		"id", "store_identifier", "type", "display_name",
+		"app_id", "created_at",
+		"future_field_revcat_doesnt_model", "nested",
+	} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("raw response dropped key %q (issue #4 regression)", k)
+		}
+	}
+}
+
+// TestDoRaw_ReturnsBodyOnSuccess validates the underlying primitive used
+// by every Get*Raw helper.
+func TestDoRaw_ReturnsBodyOnSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"a":1,"b":"two"}`))
+	}))
+	defer srv.Close()
+
+	c := New(Options{SecretKey: "sk", BaseURL: srv.URL})
+
+	var dst struct {
+		A int `json:"a"`
+	}
+	raw, err := c.DoRaw(context.Background(), "GET", "/anything", nil, &dst)
+	if err != nil {
+		t.Fatalf("DoRaw: %v", err)
+	}
+	if dst.A != 1 {
+		t.Errorf("typed decode failed: %+v", dst)
+	}
+	if string(raw) != `{"a":1,"b":"two"}` {
+		t.Errorf("raw body mismatch: %s", raw)
+	}
+}
+
+// TestCustomerSnapshot_MarshalJSON_PassesRawThrough exercises the
+// MarshalJSON override that keeps subscriber snapshots field-complete.
+func TestCustomerSnapshot_MarshalJSON_PassesRawThrough(t *testing.T) {
+	snap := &CustomerSnapshot{
+		RawCustomer:     json.RawMessage(`{"id":"u1","extra":"keep"}`),
+		RawEntitlements: []json.RawMessage{json.RawMessage(`{"id":"e1","new_field":42}`)},
+	}
+	out, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"extra":"keep"`) {
+		t.Errorf("customer raw passthrough lost: %s", out)
+	}
+	if !strings.Contains(string(out), `"new_field":42`) {
+		t.Errorf("entitlements raw passthrough lost: %s", out)
+	}
+}

--- a/internal/api/subscriptions.go
+++ b/internal/api/subscriptions.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/url"
 )
@@ -44,6 +45,20 @@ func (c *Client) GetSubscription(ctx context.Context, subID string) (*Subscripti
 		return nil, err
 	}
 	return &s, nil
+}
+
+// GetSubscriptionRaw fetches a subscription and returns the verbatim v2
+// response alongside the typed projection.
+func (c *Client) GetSubscriptionRaw(ctx context.Context, subID string) (*SubscriptionFull, json.RawMessage, error) {
+	if err := c.requireProject(); err != nil {
+		return nil, nil, err
+	}
+	var s SubscriptionFull
+	raw, err := c.DoRaw(ctx, "GET", c.projectPath("/subscriptions/"+url.PathEscape(subID)), nil, &s)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &s, raw, nil
 }
 
 // ListSubscriptionTransactions pages billing events for a subscription.
@@ -152,6 +167,20 @@ func (c *Client) GetPurchase(ctx context.Context, purchaseID string) (*PurchaseF
 		return nil, err
 	}
 	return &p, nil
+}
+
+// GetPurchaseRaw fetches a purchase and returns the verbatim v2 response
+// alongside the typed projection.
+func (c *Client) GetPurchaseRaw(ctx context.Context, purchaseID string) (*PurchaseFull, json.RawMessage, error) {
+	if err := c.requireProject(); err != nil {
+		return nil, nil, err
+	}
+	var p PurchaseFull
+	raw, err := c.DoRaw(ctx, "GET", c.projectPath("/purchases/"+url.PathEscape(purchaseID)), nil, &p)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &p, raw, nil
 }
 
 // ListPurchaseEntitlements lists entitlements granted by a purchase.


### PR DESCRIPTION
Fixes #4.

## What was broken

`revcat <resource> view <id> --output json [--pretty]` returned the typed Go struct projection from `internal/api/<resource>.go`, not the raw v2 response. Any field the struct did not model was silently dropped on output. The issue's smoking gun: products were missing `app_id`, `created_at`, `store_identifier`, etc.

## What changed

Pattern used everywhere: keep the typed struct (table renderer still wants it for its column picks) and add a sibling `Get*Raw` helper that returns `(typed, json.RawMessage, error)`. View commands switch to the Raw helper and emit the raw bytes when the resolved output is JSON.

| resource | api change | command change |
| --- | --- | --- |
| products | `GetProductRaw` | products view emits raw |
| packages | `GetPackageRaw` | packages view emits raw |
| offerings | `GetOfferingRaw` | offerings view emits raw on default JSON; `--packages` still merges typed |
| entitlements | `GetEntitlementRaw` | entitlements view emits raw |
| webhooks | `GetWebhookRaw` | webhooks view emits raw |
| virtual-currencies | `GetVirtualCurrencyRaw` | virtual-currencies view emits raw |
| subscriptions | `GetSubscriptionRaw` | subscriptions view emits raw |
| purchases | `GetPurchaseRaw` | purchases view emits raw |
| apps | `GetAppRaw` | apps view emits raw |
| projects | `GetProjectRaw` (paginates list and returns the matching item bytes; v2 has no per-id endpoint) | projects view emits raw |
| subscribers (info) | `CustomerSnapshot` gains `Raw*` byte buffers + `MarshalJSON` that prefers raw bytes over the typed projection; `paginateBoth` helper | no command change needed |
| paywalls / invoices | already returned `map[string]any` (effectively raw) | no change |

The underlying primitive is `Client.DoRaw`, which mirrors `Do` but also returns the verbatim body. `Do` is now a thin wrapper, so existing call sites are untouched.

## Before / after for the issue's example

Before (`revcat products view prod8af0c2ae8c --output json --pretty`):

```json
{
  "id": "prod8af0c2ae8c",
  "store_identifier": "app.monthly",
  "type": "subscription",
  "display_name": "Monthly",
  "app_id": "app_abc"
}
```

After: returns whatever v2 returns, including `created_at`, any nested objects, and any v2 fields revcat does not model. Captured by `TestGetProductRaw_PreservesAllV2Fields` which feeds in a payload containing `future_field_revcat_doesnt_model` and asserts it survives.

## Tests

`internal/api/raw_test.go` covers:

- `TestDoRaw_ReturnsBodyOnSuccess` - the underlying primitive
- `TestGetProductRaw_PreservesAllV2Fields` - the issue regression
- `TestCustomerSnapshot_MarshalJSON_PassesRawThrough` - subscribers info path

`go vet ./...` clean. `go test ./...` clean.

## Notes / scope

- Did not add the optional `--fields a,b,c` curation flag (issue said correctness over feature breadth). Easy follow-up if anyone wants it.
- `--output json` on table-only data (lists rendered through `output.Table`) was not in scope; only the `view` paths.
- `offerings view --packages` (default true on TTY) still returns the typed merge so packages render alongside the offering. On `--output json` the default flips to false so the response is verbatim v2; users can pass `--packages` explicitly to opt back into the stitched typed shape.

## Test plan

- [ ] `revcat products view <id> --output json --pretty` includes `app_id`, `created_at`, `store_identifier`
- [ ] Same check for one of: packages / offerings / entitlements / subscriptions / purchases / webhooks / apps / projects
- [ ] `revcat subscribers info <user> --output json` includes any v2 fields beyond what the typed structs modeled (e.g., `attributes` keys on the customer object)
- [ ] Table renders unchanged for all view commands

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->