### PR TITLE
Escape appID in projects.go URL paths (and audit siblings)

### DIFF
--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"net/url"
 )
 
 // Project is the v2 representation of a RevenueCat project. Trimmed to the
@@ -113,7 +114,7 @@ func (c *Client) GetApp(ctx context.Context, appID string) (*App, error) {
 		return nil, err
 	}
 	var a App
-	if err := c.Do(ctx, "GET", c.projectPath("/apps/"+appID), nil, &a); err != nil {
+	if err := c.Do(ctx, "GET", c.projectPath("/apps/"+url.PathEscape(appID)), nil, &a); err != nil {
 		return nil, err
 	}
 	return &a, nil
@@ -125,7 +126,7 @@ func (c *Client) GetAppRaw(ctx context.Context, appID string) (*App, json.RawMes
 		return nil, nil, err
 	}
 	var a App
-	raw, err := c.DoRaw(ctx, "GET", c.projectPath("/apps/"+appID), nil, &a)
+	raw, err := c.DoRaw(ctx, "GET", c.projectPath("/apps/"+url.PathEscape(appID)), nil, &a)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -137,7 +138,7 @@ func (c *Client) ListPublicAPIKeys(ctx context.Context, appID string) ([]PublicA
 	if err := c.requireProject(); err != nil {
 		return nil, err
 	}
-	return paginate[PublicAPIKey](ctx, c, c.projectPath("/apps/"+appID+"/public_api_keys"))
+	return paginate[PublicAPIKey](ctx, c, c.projectPath("/apps/"+url.PathEscape(appID)+"/public_api_keys"))
 }
 
 // GetStoreKitConfig returns the StoreKit configuration for an app (iOS).
@@ -147,7 +148,7 @@ func (c *Client) GetStoreKitConfig(ctx context.Context, appID string) (map[strin
 		return nil, err
 	}
 	var out map[string]any
-	if err := c.Do(ctx, "GET", c.projectPath("/apps/"+appID+"/store_kit_config"), nil, &out); err != nil {
+	if err := c.Do(ctx, "GET", c.projectPath("/apps/"+url.PathEscape(appID)+"/store_kit_config"), nil, &out); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/internal/api/projects_test.go
+++ b/internal/api/projects_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGetApp_EscapesAppID is the regression test for issue #16. The v2
+// API path for /apps/{id} must percent-encode the app id so that ids
+// containing path-significant characters (slashes, question marks) do
+// not change which endpoint is hit.
+func TestGetApp_EscapesAppID(t *testing.T) {
+	const trickyID = "app/with?weird"
+	// url.PathEscape leaves "/" alone but escapes "?". Confirm we hit a
+	// path that no longer contains the raw "?" delimiter.
+	var seenPath, seenRawPath, seenRawQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		seenRawPath = r.URL.EscapedPath()
+		seenRawQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"app_abc","name":"x","type":"ios","created_at":0}`))
+	}))
+	defer srv.Close()
+
+	c := New(Options{SecretKey: "sk", ProjectID: "proj_xyz", BaseURL: srv.URL})
+
+	if _, err := c.GetApp(context.Background(), trickyID); err != nil {
+		t.Fatalf("GetApp: %v", err)
+	}
+
+	// "?" in the id must not have leaked into the query string.
+	if seenRawQuery != "" {
+		t.Errorf("query string should be empty, got %q (path=%q)", seenRawQuery, seenPath)
+	}
+
+	// Escaped path must contain the encoded "?" (%3F) inside the id.
+	if !strings.Contains(seenRawPath, "%3F") {
+		t.Errorf("expected %%3F in escaped path, got %q", seenRawPath)
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/api/projects.go` was concatenating `appID` directly into v2 paths (`/apps/{id}`, `/apps/{id}/public_api_keys`, `/apps/{id}/store_kit_config`). Every other resource file (`customers.go`, `offerings.go`, `products.go`, `paywalls.go`, `subscriptions.go`, `entitlements.go`, `metrics.go`) already wraps ids with `url.PathEscape`. This brings projects.go in line.
- Adds `internal/api/projects_test.go` with a regression test that calls `GetApp` with an id containing `/` and `?`, and asserts the `?` does not leak into `r.URL.RawQuery` and is encoded as `%3F` in the escaped path.

## Audit findings

I ran `grep -rn '"+ \\|" + ' internal/api/ | grep -E '(ID|id)\\b'` to sweep the rest of the package:

- All `*ID` parameters used in path concatenation are already wrapped in `url.PathEscape` everywhere except projects.go (now fixed).
- Several call sites concatenate a literal `action` string (`"archive"`/`"unarchive"`, etc.) into paths. These are local enum constants, not user input, so escaping is unnecessary.
- One ambiguous case worth flagging: `customers.go:84` `projectPath` does `"/projects/" + c.projectID + suffix` without escaping. `c.projectID` originates from the auth profile (`REVCAT_PROJECT_ID` env or stored profile) so it is effectively trusted, but escaping it would cost nothing and would harden against a malformed config. Left out of this PR to keep the diff scoped to the issue. Happy to follow up in a separate PR if you want.

Closes #16

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` passes (new test included)
- [ ] Manual `revcat apps view <id>` against a real project (skipped, no live creds in this env)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->