### PR TITLE
Pin jose2go to v1.7.0 (close DoS CVEs)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,3 +36,7 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
 )
+
+// Pin jose2go to v1.7.0 to address DoS CVEs (GO-2025-4123, GO-2023-2409).
+// 99designs/keyring transitively pulls v1.5.0.
+replace github.com/dvsekhvalnov/jose2go => github.com/dvsekhvalnov/jose2go v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQxaLAeM=
-github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
+github.com/dvsekhvalnov/jose2go v1.7.0 h1:bnQc8+GMnidJZA8zc6lLEAb4xNrIqHwO+9TzqvtQZPo=
+github.com/dvsekhvalnov/jose2go v1.7.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=


### PR DESCRIPTION
## Summary

`github.com/dvsekhvalnov/jose2go v1.5.0` is pulled transitively by `99designs/keyring` and is affected by two known DoS vulnerabilities:

- [GO-2025-4123](https://pkg.go.dev/vuln/GO-2025-4123) — DoS via crafted JWE token with high compression ratio
- [GO-2023-2409](https://pkg.go.dev/vuln/GO-2023-2409) — DoS when decrypting attacker-controlled input

Both reach the keychain auth path (`internal/auth/auth.go` `keychainStore.Get`/`Set` -> `keyring.fileKeyring.Get`/`Set` -> `jose2go.Decode`/`Encrypt`).

This PR adds a `replace` directive pinning `jose2go` to v1.7.0, which fixes both. No upstream `99designs/keyring` release has bumped its `jose2go` floor yet, so a `replace` is the cleanest available fix.

Closes #12

## govulncheck before

```
Vulnerability #1: GO-2025-4123
    Denial-of-Service (DoS) via crafted JSON Web Encryption (JWE) token high
    compression ratio in github.com/dvsekhvalnov/jose2go
  Module: github.com/dvsekhvalnov/jose2go
    Found in: github.com/dvsekhvalnov/jose2go@v1.5.0
    Fixed in: github.com/dvsekhvalnov/jose2go@v1.7.0
    Example traces found:
      #1: internal/auth/auth.go:122:25: auth.keychainStore.Get calls keyring.fileKeyring.Get, which calls jose2go.Decode

Vulnerability #2: GO-2023-2409
    Denial of service when decrypting attacker controlled input in
    github.com/dvsekhvalnov/jose2go
  Module: github.com/dvsekhvalnov/jose2go
    Found in: github.com/dvsekhvalnov/jose2go@v1.5.0
    Fixed in: github.com/dvsekhvalnov/jose2go@v1.5.1-0.20231206184617-48ba0b76bc88
    Example traces found:
      #1: internal/auth/auth.go:122:25: auth.keychainStore.Get calls keyring.fileKeyring.Get, which calls jose2go.Decode
      #2: internal/auth/auth.go:141:19: auth.keychainStore.Set calls keyring.fileKeyring.Set, which calls jose2go.Encrypt

Your code is affected by 2 vulnerabilities from 1 module.
```

## govulncheck after

```
No vulnerabilities found.
```

## Test plan

- [x] `go mod tidy` clean
- [x] `go mod verify` reports `all modules verified`
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
- [x] `govulncheck ./...` reports no vulnerabilities

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->