### PR TITLE
Atomic writes for ~/.revcat/config.json

### DIFF
--- a/internal/auth/active.go
+++ b/internal/auth/active.go
@@ -24,6 +24,10 @@ func activeFilePath() (string, error) {
 }
 
 // SetActive persists the active profile name. Creates ~/.revcat if missing.
+//
+// Writes are atomic via tempfile + rename so a Ctrl-C mid-write or two
+// concurrent `revcat auth use` invocations cannot leave a half-written
+// active file.
 func SetActive(name string) error {
 	path, err := activeFilePath()
 	if err != nil {
@@ -32,7 +36,7 @@ func SetActive(name string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
-	return os.WriteFile(path, []byte(name+"\n"), 0o600)
+	return atomicWriteFile(path, []byte(name+"\n"), 0o600)
 }
 
 // GetActive reads the active profile name. Returns empty string if unset

--- a/internal/auth/atomic.go
+++ b/internal/auth/atomic.go
@@ -1,0 +1,80 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// atomicWriteJSON marshals v as indented JSON and writes it to path
+// atomically: a tempfile is created in the destination directory, mode is
+// fixed to 0600 BEFORE any bytes are written, the bytes are flushed to
+// disk, and then the tempfile is renamed over path.
+//
+// On any failure the tempfile is removed so we don't litter the directory.
+// A successful rename preserves the tempfile's 0600 mode on the final file.
+func atomicWriteJSON(path string, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(path, b, 0o600)
+}
+
+// atomicWriteFile writes data to path via tempfile + rename. Mode is set on
+// the tempfile before writing, so the final file has the requested mode.
+//
+// writerFn lets tests inject a writer that fails mid-stream.
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	return atomicWriteWith(path, mode, func(w io.Writer) error {
+		_, err := w.Write(data)
+		return err
+	})
+}
+
+// atomicWriteWith is the underlying primitive: it creates a tempfile in
+// dir(path), chmods to mode, calls writeFn with the file as an io.Writer,
+// fsyncs, closes, and renames. On any error the tempfile is removed.
+func atomicWriteWith(path string, mode os.FileMode, writeFn func(io.Writer) error) (err error) {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, ".revcat-tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tempPath := f.Name()
+
+	// Always try to remove the tempfile. After a successful rename the
+	// original tempPath no longer exists, so Remove is a harmless no-op.
+	defer func() {
+		_ = os.Remove(tempPath)
+	}()
+
+	// Set restrictive mode BEFORE writing so the bytes never sit on disk
+	// world-readable. On platforms where Chmod is a no-op (Windows) this
+	// is best-effort; the rename below still gives an atomic swap.
+	if chmodErr := os.Chmod(tempPath, mode); chmodErr != nil {
+		_ = f.Close()
+		return fmt.Errorf("chmod temp file: %w", chmodErr)
+	}
+
+	if writeErr := writeFn(f); writeErr != nil {
+		_ = f.Close()
+		return writeErr
+	}
+
+	if syncErr := f.Sync(); syncErr != nil {
+		_ = f.Close()
+		return fmt.Errorf("sync temp file: %w", syncErr)
+	}
+
+	if closeErr := f.Close(); closeErr != nil {
+		return fmt.Errorf("close temp file: %w", closeErr)
+	}
+
+	if renameErr := os.Rename(tempPath, path); renameErr != nil {
+		return fmt.Errorf("rename temp file: %w", renameErr)
+	}
+	return nil
+}

--- a/internal/auth/atomic_test.go
+++ b/internal/auth/atomic_test.go
@@ -1,0 +1,186 @@
+package auth
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func TestAtomicWriteJSON_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	payload := localFile{Profiles: map[string]Profile{
+		"default": {Name: "default", SecretKey: "sk_live_abc", ProjectID: "proj_1"},
+	}}
+	if err := atomicWriteJSON(path, &payload); err != nil {
+		t.Fatalf("atomicWriteJSON: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Errorf("file mode = %o, want 0600", got)
+		}
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// Cheap content check: payload should round-trip through the JSON we wrote.
+	if !contains(b, []byte(`"sk_live_abc"`)) || !contains(b, []byte(`"proj_1"`)) {
+		t.Errorf("content missing expected fields: %s", b)
+	}
+}
+
+func TestAtomicWriteJSON_NoLeftoverTempfileOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	if err := atomicWriteJSON(path, map[string]string{"k": "v"}); err != nil {
+		t.Fatalf("atomicWriteJSON: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "config.json" {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected only config.json, got %v", names)
+	}
+}
+
+func TestAtomicWriteWith_FailureLeavesDestinationUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	// Pre-populate with a known good file.
+	original := []byte(`{"profiles":{"default":{"name":"default","secret_key":"original"}}}` + "\n")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Simulate a writer that errors after a few bytes.
+	failErr := errors.New("simulated mid-write failure")
+	werr := atomicWriteWith(path, 0o600, func(w io.Writer) error {
+		if _, err := w.Write([]byte("garbage-prefix")); err != nil {
+			return err
+		}
+		return failErr
+	})
+	if !errors.Is(werr, failErr) {
+		t.Fatalf("expected wrapped failErr, got %v", werr)
+	}
+
+	// Destination must still contain the original bytes.
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("destination mutated.\n got: %s\nwant: %s", got, original)
+	}
+
+	// And no tempfile should be left in dir.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected only config.json after failure, got %v", names)
+	}
+}
+
+func TestAtomicWriteFile_ConcurrentWritesNoCorruption(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	a := []byte(`{"profiles":{"a":{"name":"a","secret_key":"AAA"}}}` + "\n")
+	b := []byte(`{"profiles":{"b":{"name":"b","secret_key":"BBB"}}}` + "\n")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			if err := atomicWriteFile(path, a, 0o600); err != nil {
+				t.Errorf("writer A: %v", err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			if err := atomicWriteFile(path, b, 0o600); err != nil {
+				t.Errorf("writer B: %v", err)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	final, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// File must contain exactly one of the two contents, never an interleaved
+	// fragment.
+	if string(final) != string(a) && string(final) != string(b) {
+		t.Errorf("file content is neither A nor B: %s", final)
+	}
+}
+
+func TestAtomicWriteJSON_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	if err := atomicWriteJSON(path, map[string]int{"v": 1}); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := atomicWriteJSON(path, map[string]int{"v": 2}); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !contains(got, []byte(`"v": 2`)) {
+		t.Errorf("expected v=2 in final file, got %s", got)
+	}
+}
+
+func contains(haystack, needle []byte) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := range needle {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/auth/local.go
+++ b/internal/auth/local.go
@@ -57,11 +57,7 @@ func (s *localStore) save(lf *localFile) error {
 	if err := writeGitignoreOnce(filepath.Dir(s.path)); err != nil {
 		return err
 	}
-	b, err := json.MarshalIndent(lf, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(s.path, b, 0o600)
+	return atomicWriteJSON(s.path, lf)
 }
 
 func writeGitignoreOnce(dir string) error {


### PR DESCRIPTION
## Summary

- Adds `atomicWriteJSON` / `atomicWriteFile` helpers in `internal/auth/atomic.go` that write via tempfile in the destination dir, chmod to 0600 before writing, fsync, close, then rename. A failed rename or mid-write error removes the tempfile so we never litter the directory.
- Replaces `os.WriteFile` in `localStore.save` (config.json) and `SetActive` (~/.revcat/active) with the helpers, so Ctrl-C and concurrent writes can no longer leave a corrupt or half-written file.
- Adds unit tests covering the happy path (file present, mode 0600, content matches), no leftover tempfile on success, mid-write failure leaves the destination unchanged, concurrent writes never produce interleaved garbage, and overwrites land cleanly.

Fixes #15.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [ ] Manual: `revcat --bypass-keychain auth login` writes 0600 config.json
- [ ] Manual: kill `auth login` mid-write, confirm previous config is intact

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->