### PR TITLE
Add --secret-key-stdin flag (avoid shell history leak)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The RevenueCat CLI. Run your RevenueCat project from the terminal instead of cli
 ![revcat demo](./demo/demo.gif)
 
 ```sh
-revcat auth login --name my-app --secret-key sk_xxx
+echo $RC_KEY | revcat auth login --name my-app --secret-key-stdin
 revcat subscribers info app_user_123
 revcat metrics overview
 revcat publish offering pro --paywall ./paywalls/pro.json
@@ -45,12 +45,23 @@ revcat reads a RevenueCat v2 secret key (`sk_...`). One of:
 
 Profiles live in your OS keychain by default. For containers/CI, pass `--bypass-keychain` (or `REVCAT_BYPASS_KEYCHAIN=1`) and the profile is written to `./.revcat/config.json` instead. A `.gitignore` is created on first write.
 
+Recommended: pipe the key in via stdin so it never lands in your shell history.
+
 ```sh
-revcat auth login --name my-app --secret-key sk_xxx
+echo $RC_KEY | revcat auth login --name my-app --secret-key-stdin
 revcat auth status --validate
 revcat auth doctor                   # diagnose common breakage
 revcat auth list
 revcat auth use my-app
+```
+
+`--secret-key sk_...` works too, but the key is then visible in your shell
+history and any process listing. Prefer `--secret-key-stdin` for production
+and CI.
+
+```sh
+# Secondary form (key visible in history; convenient for local exploration):
+revcat auth login --name my-app --secret-key sk_xxx
 ```
 
 ## Command surface

--- a/commands/auth/auth.go
+++ b/commands/auth/auth.go
@@ -12,8 +12,11 @@ credentials is a "profile" with a name, secret key, and project id.
 
 Most users only need:
 
-    revcat auth login --name my-app --secret-key sk_...
+    echo $RC_KEY | revcat auth login --name my-app --secret-key-stdin
     revcat auth status
+
+--secret-key sk_... works too, but the key ends up in your shell history.
+Prefer --secret-key-stdin for production and CI.
 
 For CI, pass --bypass-keychain (or set REVCAT_BYPASS_KEYCHAIN=1) to use a
 local file instead, or pass REVCAT_API_KEY directly.`,

--- a/commands/auth/login.go
+++ b/commands/auth/login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -16,10 +17,11 @@ import (
 )
 
 var (
-	loginName      string
-	loginSecretKey string
-	loginProjectID string
-	loginNoVerify  bool
+	loginName        string
+	loginSecretKey   string
+	loginSecretStdin bool
+	loginProjectID   string
+	loginNoVerify    bool
 )
 
 var loginCmd = &cobra.Command{
@@ -32,16 +34,18 @@ written to your OS keychain unless --bypass-keychain is set, in which case
 it's written to ./.revcat/config.json (a .gitignore is created on first use).
 
 Examples:
-  revcat auth login                                       # interactive
-  revcat auth login --name prod --secret-key sk_xxx       # scripted
-  revcat auth login --name prod --secret-key sk_xxx \
-    --project-id proj_xxx --no-verify                     # CI`,
+  revcat auth login                                                   # interactive
+  echo $RC_KEY | revcat auth login --name prod --secret-key-stdin     # scripted, no shell history
+  revcat auth login --name prod --secret-key sk_xxx                   # scripted (key visible in history)
+  echo $RC_KEY | revcat auth login --name ci --secret-key-stdin \
+    --project-id proj_xxx --no-verify                                 # CI`,
 	RunE: runLogin,
 }
 
 func init() {
 	loginCmd.Flags().StringVarP(&loginName, "name", "n", "", "Profile name (default: 'default')")
-	loginCmd.Flags().StringVarP(&loginSecretKey, "secret-key", "k", "", "RevenueCat v2 secret key (sk_...)")
+	loginCmd.Flags().StringVarP(&loginSecretKey, "secret-key", "k", "", "RevenueCat v2 secret key (sk_...). Warning: visible in shell history; prefer --secret-key-stdin in production")
+	loginCmd.Flags().BoolVar(&loginSecretStdin, "secret-key-stdin", false, "Read the secret key from stdin (recommended for scripts/CI; avoids leaking the key into shell history)")
 	loginCmd.Flags().StringVar(&loginProjectID, "project-id", "", "Project id to bind (auto-detected from /v2/projects if omitted)")
 	loginCmd.Flags().BoolVar(&loginNoVerify, "no-verify", false, "Skip the API check that the key is valid")
 }
@@ -49,6 +53,19 @@ func init() {
 func runLogin(cmd *cobra.Command, args []string) error {
 	if loginName == "" {
 		loginName = "default"
+	}
+	if loginSecretStdin && loginSecretKey != "" {
+		return fmt.Errorf("--secret-key and --secret-key-stdin are mutually exclusive; pass only one")
+	}
+	if loginSecretStdin {
+		raw, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return fmt.Errorf("read secret key from stdin: %w", err)
+		}
+		loginSecretKey = strings.TrimSpace(string(raw))
+		if loginSecretKey == "" {
+			return fmt.Errorf("--secret-key-stdin was set but stdin was empty")
+		}
 	}
 	if loginSecretKey == "" {
 		if err := survey.AskOne(&survey.Password{Message: "RevenueCat secret key (sk_...)"}, &loginSecretKey); err != nil {

--- a/commands/auth/login_test.go
+++ b/commands/auth/login_test.go
@@ -1,0 +1,143 @@
+package auth
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	authstore "github.com/akshitkrnagpal/revcat/internal/auth"
+)
+
+// newTestRoot wires up a minimal root command with the global
+// --bypass-keychain flag and the auth subtree, matching the production
+// shape just closely enough for runLogin to find the persistent flag.
+func newTestRoot() *cobra.Command {
+	root := &cobra.Command{Use: "revcat"}
+	root.PersistentFlags().Bool("bypass-keychain", false, "")
+	root.AddCommand(Cmd)
+	return root
+}
+
+// resetLoginFlags zeros the package-level flag-bound vars so tests
+// don't leak state into each other.
+func resetLoginFlags() {
+	loginName = ""
+	loginSecretKey = ""
+	loginSecretStdin = false
+	loginProjectID = ""
+	loginNoVerify = false
+}
+
+// chdirTemp makes cwd a fresh temp dir and restores it on cleanup so
+// that the local-file authstore writes into ./.revcat/config.json
+// inside an isolated directory.
+func chdirTemp(t *testing.T) string {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	return dir
+}
+
+func TestLoginSecretKeyStdin(t *testing.T) {
+	resetLoginFlags()
+	dir := chdirTemp(t)
+
+	root := newTestRoot()
+	root.SetArgs([]string{
+		"auth", "login",
+		"--bypass-keychain",
+		"--name", "test-stdin",
+		"--secret-key-stdin",
+		"--no-verify",
+	})
+	root.SetIn(strings.NewReader("sk_test_abcdef\n"))
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	// Confirm the profile landed in the local store with the trimmed key.
+	store, err := authstore.Open(true)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	got, err := store.Get("test-stdin")
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if got.SecretKey != "sk_test_abcdef" {
+		t.Fatalf("secret key: want %q, got %q", "sk_test_abcdef", got.SecretKey)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".revcat", "config.json")); err != nil {
+		t.Fatalf("expected config.json: %v", err)
+	}
+}
+
+func TestLoginSecretKeyAndStdinMutuallyExclusive(t *testing.T) {
+	resetLoginFlags()
+	chdirTemp(t)
+
+	root := newTestRoot()
+	root.SetArgs([]string{
+		"auth", "login",
+		"--bypass-keychain",
+		"--name", "test-both",
+		"--secret-key", "sk_inline",
+		"--secret-key-stdin",
+		"--no-verify",
+	})
+	root.SetIn(strings.NewReader("sk_from_stdin\n"))
+	// Silence cobra's default error printing.
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error when both --secret-key and --secret-key-stdin are passed")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error %q does not mention mutual exclusion", err.Error())
+	}
+}
+
+func TestLoginSecretKeyStdinEmpty(t *testing.T) {
+	resetLoginFlags()
+	chdirTemp(t)
+
+	root := newTestRoot()
+	root.SetArgs([]string{
+		"auth", "login",
+		"--bypass-keychain",
+		"--name", "test-empty",
+		"--secret-key-stdin",
+		"--no-verify",
+	})
+	root.SetIn(strings.NewReader("   \n"))
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for empty stdin")
+	}
+	if !strings.Contains(err.Error(), "stdin was empty") {
+		t.Fatalf("error %q does not mention empty stdin", err.Error())
+	}
+}

--- a/skills/revcat-commands/SKILL.md
+++ b/skills/revcat-commands/SKILL.md
@@ -17,7 +17,12 @@ Conventions:
 ## auth
 
 ```sh
+# Recommended: pipe the key in via stdin so it never lands in shell history.
+echo $RC_KEY | revcat auth login --name my-app --secret-key-stdin [--project-id proj_xxx] [--no-verify]
+
+# Inline (key visible in shell history; OK for local exploration, avoid in production/CI):
 revcat auth login --name my-app --secret-key sk_xxx [--project-id proj_xxx] [--no-verify]
+
 revcat auth status [--validate]
 revcat auth doctor
 revcat auth use <name>

--- a/skills/revcat-getting-started/SKILL.md
+++ b/skills/revcat-getting-started/SKILL.md
@@ -25,10 +25,15 @@ Pre-built binaries for every platform are on the [GitHub Releases page](https://
 
 revcat reads a v2 secret key (`sk_...`) and stores it in the OS keychain.
 
+Pipe the key in via stdin so it does not land in your shell history:
+
 ```sh
-revcat auth login --name my-app --secret-key sk_xxx
+echo $RC_KEY | revcat auth login --name my-app --secret-key-stdin
 revcat auth doctor             # verify
 ```
+
+`--secret-key sk_...` works too, but the key is visible in shell history and
+process listings. Prefer `--secret-key-stdin` for production and CI.
 
 For CI / Docker (no keychain), use one of:
 
@@ -37,7 +42,7 @@ For CI / Docker (no keychain), use one of:
 REVCAT_API_KEY=sk_xxx revcat metrics overview
 
 # B: write a profile to ./.revcat/config.json (auto-gitignored)
-revcat auth login --bypass-keychain --name ci --secret-key sk_xxx --no-verify
+echo $RC_KEY | revcat auth login --bypass-keychain --name ci --secret-key-stdin --no-verify
 ```
 
 Switch profiles with `revcat auth use <name>` or `--profile <name>` per-command.

--- a/skills/revcat-troubleshooting/SKILL.md
+++ b/skills/revcat-troubleshooting/SKILL.md
@@ -20,14 +20,14 @@ Logs the full request and response (with the secret key redacted).
 The login step or any later command got 401.
 
 - Confirm you're using a **v2 secret key** (starts with `sk_`), not a public SDK key.
-- The key may have been rotated. Generate a new one in the dashboard and re-run `revcat auth login --name <name> --secret-key sk_xxx`.
+- The key may have been rotated. Generate a new one in the dashboard and re-run `echo $RC_KEY | revcat auth login --name <name> --secret-key-stdin` (or `--secret-key sk_xxx` if you don't mind the key in shell history).
 - If you're hitting a partner-tier endpoint (project create, app CRUD, audit logs, collaborators) with a project secret key, you'll see 401/403. Those are out of scope for revcat.
 
 ## "no profile found - run `revcat auth login`"
 
 There is no active profile to use.
 
-- First time: `revcat auth login --name my-app --secret-key sk_xxx`.
+- First time: `echo $RC_KEY | revcat auth login --name my-app --secret-key-stdin` (recommended, no shell-history leak), or `revcat auth login --name my-app --secret-key sk_xxx`.
 - Already logged in elsewhere? Check what's set: `revcat auth list`.
 - Switch with `revcat auth use <name>` or per-command `--profile <name>`.
 - In CI: pass `REVCAT_API_KEY=sk_xxx` directly, or use `--bypass-keychain` so revcat reads `./.revcat/config.json`.


### PR DESCRIPTION
## Summary

- Adds a `--secret-key-stdin` boolean flag to `revcat auth login` that reads the v2 secret key from stdin (until EOF), trims whitespace, and uses it. Inline `--secret-key sk_xxx` still works but the two flags are mutually exclusive.
- Same `sk_` prefix validation; same downstream verify/store path. Empty stdin errors with a clear message.
- Updates `--secret-key` help text to flag the shell-history / process-listing risk and recommend `--secret-key-stdin` for production.
- README and the `revcat-getting-started`, `revcat-commands`, and `revcat-troubleshooting` skills now lead with the stdin pattern (`echo $RC_KEY | revcat auth login --name my-app --secret-key-stdin`) and show `--secret-key sk_...` as a secondary option with a security note.

Closes #13.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` passes (3 new tests in `commands/auth/login_test.go`):
  - stdin path stores the trimmed key in the local profile
  - passing both flags returns an error mentioning "mutually exclusive"
  - empty stdin returns an error mentioning "stdin was empty"
- [ ] Manual: `echo sk_test | go run ./cmd/revcat auth login --bypass-keychain --name demo --secret-key-stdin --no-verify` writes a profile, no key in shell history
- [ ] Manual: `--secret-key sk_xxx --secret-key-stdin` together errors out

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->