### PR TITLE
alpha.3 fixes: one passphrase, no stale active markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Notable changes per release. Dates are UTC.
 
+## [v0.4.0-alpha.3](https://github.com/akshitkrnagpal/revcat/releases/tag/v0.4.0-alpha.3) - 2026-05-01
+
+UX polish on top of alpha.2: one passphrase prompt per invocation instead of three, and a self-healing fix for stale `auth use` markers that made every command fail with "no profile found" after `auth logout --all`.
+
+### Fixed
+
+- `revcat init` (and any command opening the global keyring more than once) now prompts for the file-backed keyring passphrase exactly once per invocation. Previously each open re-prompted, so a single init would ask 2-3 times. The cache is process-scoped, so subsequent invocations still ask once. The macOS Keychain / Linux Secret Service backends are unaffected (the OS handles the passphrase and never calls our prompt func).
+- `revcat auth logout --all` and `revcat auth logout <name>` now clear `~/.revcat/active` when the deleted profile was the active one. Without this, subsequent commands resolved to a missing profile and errored with "no profile found".
+- The credential resolver self-heals when `~/.revcat/active` points to a profile that no longer exists: falls through to the `default` profile (if it exists) and clears the stale marker. Saves one round-trip of confused error messages for users upgrading from earlier alpha.
+
+### Internal
+
+- New `cliutil.ClientFromResolved` lets long-running commands (init, doctor) build the API client from an already-resolved credential without re-running `Resolve` (each Resolve re-opens the global store).
+- `internal/auth.cachedPassphrase` wraps `keyring.TerminalPrompt` in a `sync.Once`. First call prompts, subsequent calls within the process reuse the value.
+- New `internal/auth.ClearActive` removes `~/.revcat/active`. Called from logout and from the resolver's self-heal path.
+
 ## [v0.4.0-alpha.2](https://github.com/akshitkrnagpal/revcat/releases/tag/v0.4.0-alpha.2) - 2026-05-01
 
 OAuth becomes the only auth flow. Per-directory credentials let agents and sandboxes operate inside a repo without touching the user's keychain. Breaking change: secret-key auth is removed.

--- a/commands/auth/logout.go
+++ b/commands/auth/logout.go
@@ -61,6 +61,9 @@ func runLogout(cmd *cobra.Command, args []string) error {
 				output.Warn("delete %q: %v", n, err)
 			}
 		}
+		if err := authstore.ClearActive(); err != nil {
+			output.Warn("clear active marker: %v", err)
+		}
 		output.Success("removed %d profiles", len(names))
 		return nil
 	}
@@ -74,6 +77,11 @@ func runLogout(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("no profile named %q", name)
 		}
 		return err
+	}
+	if active, _ := authstore.GetActive(); active == name {
+		if err := authstore.ClearActive(); err != nil {
+			output.Warn("clear active marker: %v", err)
+		}
 	}
 	output.Success("removed profile %q", name)
 	return nil

--- a/commands/initcmd/init.go
+++ b/commands/initcmd/init.go
@@ -98,12 +98,14 @@ func runInit(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("init needs an authenticated profile: %w", err)
 	}
-	if resolved.Source == authstore.SourceLocal {
+	if resolved.Source == authstore.SourceLocal && !flagForce {
 		return errors.New("a .revcat/config.json already exists in this tree; pass --force to reinit")
 	}
 
-	// Build a client with whatever creds we have, no project bound yet.
-	client, _, err := cliutil.Client(cmd)
+	// Build a client from the resolved creds we already have so we
+	// don't re-open the keyring (which re-prompts for the passphrase
+	// on the file backend).
+	client, err := cliutil.ClientFromResolved(cmd, resolved, "")
 	if err != nil {
 		return err
 	}
@@ -116,7 +118,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	tomlCfg := &project.Config{ProjectID: projectID}
 	var apps []project.App
 	if !flagNoApps {
-		apps, err = pickApps(cmd.Context(), cmd, projectID)
+		apps, err = pickApps(cmd.Context(), cmd, resolved, projectID)
 		if err != nil {
 			return err
 		}
@@ -204,7 +206,7 @@ func pickProjectID(parent context.Context, cmd *cobra.Command, client *api.Clien
 	return projects[idx].ID, nil
 }
 
-func pickApps(parent context.Context, cmd *cobra.Command, projectID string) ([]project.App, error) {
+func pickApps(parent context.Context, cmd *cobra.Command, resolved *authstore.Resolved, projectID string) ([]project.App, error) {
 	if len(flagAppIDs) > 0 {
 		out := make([]project.App, len(flagAppIDs))
 		for i, id := range flagAppIDs {
@@ -212,7 +214,7 @@ func pickApps(parent context.Context, cmd *cobra.Command, projectID string) ([]p
 		}
 		return out, nil
 	}
-	scoped, _, err := cliutil.ClientForProject(cmd, projectID)
+	scoped, err := cliutil.ClientFromResolved(cmd, resolved, projectID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/active.go
+++ b/internal/auth/active.go
@@ -55,3 +55,17 @@ func GetActive() (string, error) {
 	}
 	return strings.TrimSpace(string(b)), nil
 }
+
+// ClearActive removes ~/.revcat/active. Used by `auth logout` when the
+// removed profile was the active one - leaving a stale pointer would
+// make every subsequent command resolve to a missing profile.
+func ClearActive() error {
+	path, err := activeFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/99designs/keyring"
@@ -122,12 +123,33 @@ func openKeychain() (GlobalStore, error) {
 		KeychainTrustApplication: true,
 		KeychainSynchronizable:   false,
 		FileDir:                  "~/.revcat/keyring",
-		FilePasswordFunc:         keyring.TerminalPrompt,
+		FilePasswordFunc:         cachedPassphrase,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("open keychain: %w", err)
 	}
 	return &keychainStore{ring: ring}, nil
+}
+
+// cachedPassphrase wraps keyring.TerminalPrompt in a process-scoped
+// sync.Once. The file-backend keyring (used on macOS without cgo and on
+// Linux without secret-service) re-prompts for the passphrase on every
+// open, which means a single `revcat init` would prompt 2-3 times. We
+// only need the user to enter it once per invocation.
+//
+// macOS Keychain / Linux Secret Service backends don't call this func
+// at all (the OS holds the passphrase), so the cache is harmless there.
+var (
+	passOnce sync.Once
+	passVal  string
+	passErr  error
+)
+
+func cachedPassphrase(prompt string) (string, error) {
+	passOnce.Do(func() {
+		passVal, passErr = keyring.TerminalPrompt(prompt)
+	})
+	return passVal, passErr
 }
 
 func (s *keychainStore) Get(name string) (*Profile, error) {

--- a/internal/auth/resolve.go
+++ b/internal/auth/resolve.go
@@ -105,7 +105,24 @@ func Resolve(opts ResolveOptions) (*Resolved, error) {
 	name := ResolveProfileName(opts.FlagProfile)
 	prof, err := store.Get(name)
 	if err != nil {
-		return nil, err
+		// Self-heal: if the active marker (set by `auth use <foo>`)
+		// points to a profile that no longer exists, fall through
+		// to "default" rather than make every subsequent command
+		// fail with ErrNoProfile.
+		if errors.Is(err, ErrNoProfile) && opts.FlagProfile == "" && os.Getenv(envProfile) == "" {
+			active, _ := GetActive()
+			if active == name && active != defaultProfile {
+				if alt, gerr := store.Get(defaultProfile); gerr == nil {
+					_ = ClearActive()
+					prof = alt
+					name = defaultProfile
+					err = nil
+				}
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	source := SourceKeychain

--- a/internal/auth/resolve_test.go
+++ b/internal/auth/resolve_test.go
@@ -71,3 +71,36 @@ func TestDecodeProfile_AcceptsOAuthShape(t *testing.T) {
 		t.Fatalf("got %+v", p)
 	}
 }
+
+func TestResolve_SelfHealsStaleActiveMarker(t *testing.T) {
+	t.Setenv("REVCAT_REFRESH_TOKEN", "")
+	t.Setenv("REVCAT_PROFILE", "")
+	t.Setenv("HOME", t.TempDir())
+
+	// Set up a global file store with only "default", then point the
+	// active marker at "ghost" (a profile that no longer exists).
+	store, err := openGlobalFile()
+	if err != nil {
+		t.Fatalf("openGlobalFile: %v", err)
+	}
+	if err := store.Set(&Profile{Name: "default", AccessToken: "atk", RefreshToken: "rtk"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := SetActive("ghost"); err != nil {
+		t.Fatalf("SetActive: %v", err)
+	}
+
+	got, err := Resolve(ResolveOptions{Bypass: true, Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Profile.Name != "default" {
+		t.Fatalf("expected fallback to default, got %q", got.Profile.Name)
+	}
+
+	// And the stale marker should be cleared so subsequent runs are
+	// fast paths.
+	if active, _ := GetActive(); active != "" {
+		t.Fatalf("expected active marker cleared, got %q", active)
+	}
+}

--- a/internal/cliutil/cliutil.go
+++ b/internal/cliutil/cliutil.go
@@ -108,21 +108,35 @@ func ClientForProject(cmd *cobra.Command, projectIDOverride string) (*api.Client
 	if err != nil {
 		return nil, nil, err
 	}
+	client, err := ClientFromResolved(cmd, resolved, projectIDOverride)
+	if err != nil {
+		return nil, nil, err
+	}
+	return client, resolved, nil
+}
 
+// ClientFromResolved builds the API client from an already-resolved
+// credential. Lets long-running commands (init, doctor) avoid re-running
+// Resolve when they already hold one - each Resolve call re-opens the
+// global store, which is cheap on a real keychain but re-prompts the
+// file-backed keyring for its passphrase.
+func ClientFromResolved(cmd *cobra.Command, resolved *authstore.Resolved, projectIDOverride string) (*api.Client, error) {
 	pid := projectIDOverride
 	if pid == "" {
 		pid = ResolveProjectID(cmd, resolved)
 	}
 
 	// For SourceKeychain / SourceGlobalFile the OAuthTokenSource
-	// needs a store handle to persist refreshed tokens back. Open
-	// the matching store; cheap.
+	// needs a store handle to persist refreshed tokens back. The
+	// passphrase prompt is cached per-process so this is free-ish
+	// after the first open.
 	var store authstore.GlobalStore
+	var err error
 	switch resolved.Source {
 	case authstore.SourceKeychain, authstore.SourceGlobalFile:
 		store, err = authstore.OpenGlobal(BypassKeychain(cmd))
 		if err != nil {
-			return nil, nil, fmt.Errorf("reopen global store for refresh: %w", err)
+			return nil, fmt.Errorf("reopen global store for refresh: %w", err)
 		}
 	}
 
@@ -131,5 +145,5 @@ func ClientForProject(cmd *cobra.Command, projectIDOverride string) (*api.Client
 		Version:     cmd.Root().Version,
 		TokenSource: authstore.NewOAuthTokenSource(resolved, store),
 	}
-	return api.New(opts), resolved, nil
+	return api.New(opts), nil
 }


### PR DESCRIPTION
## Summary

UX polish on top of alpha.2:

1. **One passphrase per invocation.** `revcat init` was prompting for the file-backed keyring passphrase 2-3 times. Each global-store open re-prompted. Now a `sync.Once`-wrapped `cachedPassphrase` keeps the value for the rest of the invocation. macOS Keychain / Linux Secret Service backends are unaffected (the OS handles passphrases without calling our prompt func).

2. **`auth logout` clears the active marker.** `revcat auth logout --all` (and `auth logout <name>` when name == active) now removes `~/.revcat/active`. Without this, subsequent commands resolved to a missing profile.

3. **Resolver self-heals stale active markers.** If `~/.revcat/active` names a profile that doesn't exist, fall through to `default` (when it exists) and clear the stale marker.

## Why

This is the bug @akshitkrnagpal hit during alpha.2 smoke testing: `auth logout --all` cleared the keychain entries, `auth login` created a fresh `default`, but `~/.revcat/active` still pointed at `oauth-test` from alpha.1 testing. Every command saw "no profile found" while `auth list` happily showed `default` (it bypasses the active-marker path).

## Internal

- `cliutil.ClientFromResolved` lets long-running commands (init, doctor) build the API client without re-running `Resolve`.
- Init drops from ~3 keyring opens to 1 (just the initial resolve).

## Test plan

- [ ] After `auth logout --all`, `auth login`, `init` should prompt for passphrase once (not three times).
- [ ] After `auth logout --all`, `~/.revcat/active` should not exist.
- [ ] If you manually `echo ghost > ~/.revcat/active` with only a `default` profile, `revcat auth status` should succeed (falling through to default) and clear the marker.

`go test ./...` green; new `TestResolve_SelfHealsStaleActiveMarker` covers the third bullet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->