### PR TITLE
Docs/skills audit: full v0.4 alignment pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,19 +12,24 @@ The RevenueCat CLI. Go + cobra.
 ## Architecture
 
 - `cmd/revcat` - main() entrypoint, calls commands.Execute()
-- `commands/` - cobra commands organized by resource (auth, apps, ...)
-- `internal/api` - hand-rolled RC v2 REST client (no SDK exists)
-- `internal/auth` - keychain + local-file backends, profile resolver
+- `commands/` - cobra commands organized by resource (auth, init, apps, ...)
+- `internal/api` - hand-rolled RC v2 REST client (no SDK exists) + OAuth flow
+- `internal/auth` - keychain / global file / project-local credential stores + resolver
+- `internal/project` - revcat.toml loader (committed half of project context)
+- `internal/cliutil` - shared command helpers (Client, ResolveProjectID)
 - `internal/output` - TTY-aware renderer (table on TTY, JSON when piped)
 
 ## Auth
 
-Profiles in OS keychain by default. Override:
+OAuth-only since v0.4. Three credential storage tiers (resolution order):
 
-- `--bypass-keychain` or `REVCAT_BYPASS_KEYCHAIN=1` writes to `./.revcat/config.json`
-- `REVCAT_API_KEY` env synthesizes a one-shot profile (highest precedence)
-- `REVCAT_PROFILE` selects active profile when `--profile` is not set
-- `REVCAT_PROJECT_ID` overrides stored project id
+1. `REVCAT_REFRESH_TOKEN` env (synthesizes a virtual profile, in-memory only)
+2. Walked-up `./.revcat/config.json` (written by `revcat init`, gitignored, mode 0600)
+3. Global keychain (default) or `~/.revcat/config.json` with `--bypass-keychain` / `REVCAT_BYPASS_KEYCHAIN=1`
+
+Within tier 3, the active profile name is `--profile` flag > `REVCAT_PROFILE` env > `~/.revcat/active` > `default`.
+
+Project id resolution: `--project-id` flag > `REVCAT_PROJECT_ID` env > resolved credential's bound project (local config or env hatch) > walked-up `revcat.toml`.
 
 ## Style
 

--- a/docs/src/content/docs/commands/index.md
+++ b/docs/src/content/docs/commands/index.md
@@ -49,7 +49,7 @@ revcat is organized by RevenueCat resource: customers, offerings, paywalls, etc.
 
 ## Auth + housekeeping
 
-`auth` (login, status, doctor, use, list, logout), `doctor`, `completion`, `version`. See the individual pages for details.
+[`auth`](/commands/auth/) (login, status, doctor, use, list, logout), [`init`](/commands/init/), [`doctor`](/commands/doctor/), `completion`, `version`. See the individual pages for details.
 
 ## Global flags
 
@@ -57,8 +57,9 @@ Available on every command:
 
 | Flag | Description |
 | --- | --- |
-| `--profile <name>` | Auth profile to use (default: `REVCAT_PROFILE` env or `default`) |
-| `--bypass-keychain` | Read/write the active profile from `./.revcat/config.json` instead of the OS keychain |
+| `--profile <name>` | Global auth profile to use (default: `REVCAT_PROFILE` env or `default`). Ignored when a `.revcat/config.json` is walked up from cwd. |
+| `--project-id <id>` | RevenueCat project id (default: `REVCAT_PROJECT_ID`, walked-up `.revcat/config.json`, or `revcat.toml`) |
+| `--bypass-keychain` | Use `~/.revcat/config.json` (file backend) instead of the OS keychain |
 | `--output table\|json\|csv\|markdown` | Force an output format. Auto-detected when omitted (table on TTY, JSON when piped) |
 | `--pretty` | Indent JSON output |
 | `-v, --verbose` | Show detailed output |

--- a/docs/src/content/docs/commands/init.md
+++ b/docs/src/content/docs/commands/init.md
@@ -1,0 +1,98 @@
+---
+title: init
+description: Bootstrap project context (revcat.toml + .revcat/config.json) for the current directory.
+---
+
+`revcat init` binds the current directory to a RevenueCat project. Run it once per repo after `revcat auth login`. After init, every command run inside the directory inherits the project context — no `--project-id` flag, no env var, no keychain access required (agents and sandboxes can drop in and just work).
+
+## What it writes
+
+| File | Committed? | Mode | Purpose |
+| --- | --- | --- | --- |
+| `revcat.toml` | yes | 0644 | `project_id` + optional `apps[]`. Documents which RC project this repo belongs to. |
+| `.revcat/config.json` | no (gitignored) | 0600 | OAuth credential blob + `project_id` + `apps`. Walked up from cwd by every revcat command. |
+
+`.revcat/` is auto-appended to `.gitignore` (idempotent). The committed half (`revcat.toml`) is non-secret; the gitignored half (`.revcat/config.json`) carries the refresh token and must not be committed.
+
+## Synopsis
+
+```sh
+revcat init [flags]
+```
+
+Requires an authenticated global profile (run `revcat auth login` first), or `REVCAT_REFRESH_TOKEN` set in the environment.
+
+## Flags
+
+| Flag | Description |
+| --- | --- |
+| `--project-id <id>` | Skip the project picker and use this id (also reads from `REVCAT_PROJECT_ID`) |
+| `--app-id <id>` | Record an app id (repeatable). Skips the app picker. |
+| `--no-apps` | Skip the apps section entirely (still writes `project_id`) |
+| `--no-local-creds` | Write only `revcat.toml`; skip `.revcat/config.json` |
+| `--force` | Overwrite an existing `revcat.toml` or `.revcat/config.json` |
+| `--path <dir>` | Where to write files (default: cwd) |
+
+## Examples
+
+Interactive — pick project + apps from a list:
+
+```sh
+cd ~/your-repo
+revcat init
+```
+
+Scripted — for CI / agents / re-init in another shell:
+
+```sh
+revcat init --project-id projaac376d8 --no-apps --force
+```
+
+Re-init after switching active global profile (the local config is rewritten with the new credential):
+
+```sh
+revcat auth use work
+revcat init --force
+```
+
+Just record project context without copying credentials (e.g., when committing a fresh repo and you want the next dev to log in themselves):
+
+```sh
+revcat init --project-id projaac376d8 --no-local-creds
+```
+
+## After init
+
+Inside the directory, project-scoped commands work without flags:
+
+```sh
+revcat offerings list
+revcat entitlements list
+revcat publish offering pro --paywall ./paywalls/pro.json
+```
+
+`cd` out of the directory and the binding goes away — commands fall back to the global keychain, and project-scoped commands need `--project-id`.
+
+## Verifying
+
+```sh
+revcat auth status --validate
+```
+
+`source` should be `local` and `source_path` should point at your `.revcat/config.json`. `project_source` should be that same path.
+
+## Mismatch detector
+
+If `revcat.toml.project_id` and `.revcat/config.json.project_id` disagree (e.g., someone hand-edited the toml), `revcat auth doctor` flags it:
+
+```text
+FAIL  toml/local mismatch  revcat.toml says proj_x, .revcat/config.json says proj_y
+      hint: rerun `revcat init --force` to realign, or edit revcat.toml to match
+```
+
+## Related
+
+- [`auth login`](/commands/auth/) — required before init
+- [`auth status`](/commands/auth/) — show resolved credential + project context
+- [`auth doctor`](/commands/auth/) — diagnose auth + project binding issues
+- [Configuration](/reference/configuration/) — full env var list and resolution order

--- a/docs/src/content/docs/reference/api-coverage.md
+++ b/docs/src/content/docs/reference/api-coverage.md
@@ -23,7 +23,7 @@ Source of truth: <https://www.revenuecat.com/docs/api-v2>.
 | --- | --- |
 | `GET /projects` | `revcat projects list`, `revcat auth login` (picker) |
 | `GET /projects/{id}` | `revcat projects view` |
-| `POST /projects` | partner-tier only |
+| `POST /projects` | not in v2 REST (dashboard only) |
 
 ### Apps
 
@@ -33,7 +33,7 @@ Source of truth: <https://www.revenuecat.com/docs/api-v2>.
 | `GET /apps/{id}` | `revcat apps view` |
 | `GET /apps/{id}/public_api_keys` | `revcat apps public-keys` |
 | `GET /apps/{id}/store_kit_config` | `revcat apps storekit-config` |
-| `POST /apps`, `POST /apps/{id}`, `DELETE /apps/{id}` | partner-tier only |
+| `POST /apps`, `POST /apps/{id}`, `DELETE /apps/{id}` | not in v2 REST (dashboard only) |
 
 ### Customers
 
@@ -186,7 +186,9 @@ Source of truth: <https://www.revenuecat.com/docs/api-v2>.
 | `GET /charts/{name}` | `revcat charts get <name>` |
 | `GET /charts/{name}/options` | `revcat charts options <name>` |
 
-## Out of scope (partner-tier keys only)
+## Out of scope (not in v2 REST)
+
+The following endpoints have no v2 REST equivalent. Manage in the dashboard.
 
 - `POST /projects` - project create
 - App CRUD (`POST /apps`, `POST /apps/{id}`, `DELETE /apps/{id}`)
@@ -194,7 +196,7 @@ Source of truth: <https://www.revenuecat.com/docs/api-v2>.
 
 ## Not exposed by v2 REST
 
-These endpoints either return 404 across the v2 customer surface or are gated behind a higher-tier key. Smoke-tested 2026-04-25:
+These endpoints return 404 across the v2 customer surface. Smoke-tested 2026-04-25:
 
 - An events firehose. RC delivers lifecycle events (purchases, renewals, cancellations, refunds, ...) via webhooks. revcat covers webhook CRUD; subscribe your endpoint with `revcat webhooks create`.
 - `POST /customers/{id}/actions/override_offering`

--- a/skills/revcat-troubleshooting/SKILL.md
+++ b/skills/revcat-troubleshooting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: revcat-troubleshooting
-description: Use when a revcat command fails or shows an error. Common errors: 401 unauthorized, no profile, no project_id, 404 customer/subscription, partner-tier endpoints, paywall PUT failures, ndjson parsing, Test Store quirks, v1-only endpoints, dashboard-only operations. Triggers on revcat error output, "revcat doesn't work", "command not supported", "atob error", "endpoint missing".
+description: Use when a revcat command fails or shows an error. Common errors: 401 unauthorized, no profile, no project_id, 404 customer/subscription, dashboard-only endpoints, paywall PUT failures, ndjson parsing, Test Store quirks, v1-only endpoints, v0.3-to-v0.4 upgrade paths, toml/local mismatch. Triggers on revcat error output, "revcat doesn't work", "command not supported", "atob error", "endpoint missing".
 ---
 
 # revcat - troubleshooting


### PR DESCRIPTION
## Summary

Follow-up audit after PR #24/#25 caught the high-traffic pages. Found three files with stale references and one missing page.

## Fixes

- **commands/index.md** — `--bypass-keychain` row had the old cwd path; now correctly says `~/.revcat/config.json`. Added missing `--project-id` global flag row. Auth+housekeeping section now links `init`, `auth`, `doctor` properly.
- **commands/init.md** (new) — `revcat init` is a top-level command with no dedicated page until now. Covers flags, what it writes, mismatch detector, verification.
- **reference/api-coverage.md** — replaced "partner-tier only" framing with "not in v2 REST" on `POST /projects`, App CRUD, and the out-of-scope section heading. The real reason these aren't exposed.
- **skills/revcat-troubleshooting** — dropped "partner-tier endpoints" from the description hint list; replaced with v0.3-to-v0.4 upgrade paths and toml/local mismatch (the actually relevant triggers now).
- **CLAUDE.md** — Auth section rewritten for the v0.4 model (three storage tiers, refresh-token env hatch, project id resolution chain). Architecture list mentions `internal/project` + `internal/cliutil`.

## Confirmed clean

- index.mdx, getting-started/quickstart, installation, all guide pages
- All command pages (entitlements, offerings, packages, products, paywalls, virtual-currencies, webhooks, subscriptions, purchases, invoices, audit-logs, charts, doctor, metrics, publish, apps, projects, subscribers, auth)
- reference/configuration
- skills/{revcat-getting-started, revcat-commands, revcat-storefront-debug, README}
- README.md

## Audit method

`grep -rn "secret.\?key\|sk_\|--secret-key\|REVCAT_API_KEY\|partner.\?tier\|auth_type" docs/ skills/ README.md CLAUDE.md` returns only one hit after this PR: the literal `## "this profile was created under v0.3 secret-key auth"` heading in revcat-troubleshooting, which is intentional (matches the migration error string users will search for).

`go test ./... && go vet ./...` green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->