### PR TITLE
docs: round out v0.4 alignment in skills/README + demo

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -7,9 +7,10 @@
 ```sh
 brew install vhs
 
-# revcat must be on $PATH and a profile must exist that points at a
-# project with at least one offering called "default".
-export REVCAT_API_KEY=sk_...
+# revcat must be on $PATH. Run `revcat auth login` once, then either
+# `revcat init` inside this directory to bind a project, or set the env
+# below for a one-off (the project must have an offering named "default").
+export REVCAT_REFRESH_TOKEN=rtk_...
 export REVCAT_PROJECT_ID=proj_...
 
 cd demo

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,12 +1,13 @@
 # revcat skills
 
-Agent Skills for revcat, distributable via [skills.sh](https://skills.sh) (planned). Each skill is a folder containing a `SKILL.md` with YAML frontmatter (`name` + `description` are required).
+Agent Skills for revcat. Each skill is a folder containing a `SKILL.md` with YAML frontmatter (`name` + `description` are required). Drop them into your agent's skills directory and the agent picks the right one based on the description.
 
 ## What's here
 
-- `revcat-getting-started/` - first-time install + auth + command map. Triggers when a user wants to start using revcat.
-- `revcat-commands/` - real syntax + examples for every subcommand. Triggers when constructing a command.
-- `revcat-troubleshooting/` - common errors and fixes. Triggers on a failed command or error message.
+- `revcat-getting-started/` — first-time install + auth (browser OAuth) + `revcat init` for per-repo project context + command map. Triggers when a user wants to start using revcat.
+- `revcat-commands/` — real syntax + examples for every subcommand including `init`. Triggers when constructing a command.
+- `revcat-troubleshooting/` — common errors and fixes (401, no profile, no project_id, v0.3-to-v0.4 upgrade paths, toml/local mismatch, Test Store quirks, v1-only endpoints, dashboard-only operations). Triggers on a failed command or error message.
+- `revcat-storefront-debug/` — 7-step diagnostic flow for "the SDK sees 0 packages from my offering." Covers the Test Store price gotcha, product/store binding checks, and the v1 `/subscribers/{id}/offerings` verify step. Triggers on "0 packages", "fetchOfferings empty", and similar SDK-side surprises.
 
 ## Install for Claude Code
 
@@ -24,7 +25,7 @@ mkdir -p .claude/skills
 cp -R skills/revcat-* .claude/skills/
 ```
 
-Restart Claude Code or open a new session - the skills will appear automatically.
+Restart Claude Code or open a new session — the skills will appear automatically.
 
 ## Install for Cursor
 
@@ -49,14 +50,11 @@ mkdir -p ~/.codex/skills
 cp -R skills/revcat-* ~/.codex/skills/
 ```
 
-If your Codex setup uses a different path, follow your local install docs - the SKILL.md format is portable across agents.
-
-## Publishing to skills.sh
-
-These skills will be published to <https://skills.sh> once revcat ships v0.1. Until then, install locally per the above. The `name` and `description` frontmatter is the trigger surface, so keep edits to the description trigger-focused.
+If your Codex setup uses a different path, follow your local install docs — the SKILL.md format is portable across agents.
 
 ## Authoring guidelines
 
-- Description should be trigger-focused ("Use when...") and front-load key terms. Keep under ~200 chars.
-- Body should be concise and example-heavy. Reference real commands - if you're unsure, check `revcat <group> --help` or the [docs](https://revcat.vercel.app).
+- Description should be trigger-focused ("Use when...") and front-load key terms. Keep under ~200 chars where possible.
+- Body should be concise and example-heavy. Reference real commands — if you're unsure, check `revcat <group> --help` or the [docs](https://revcat.vercel.app).
 - Don't invent flags. If something is genuinely TBD, leave a `TODO:` note for the maintainer.
+- After breaking changes (e.g., the v0.4 OAuth-only rewrite), do a sweep across all skills — the troubleshooting skill in particular accumulates legacy error strings users will still search for.


### PR DESCRIPTION
Two stragglers from the prior audit:

- `skills/README.md` was missing `revcat-storefront-debug` (which has been in the `skills/` folder for a while). Also dropped the pre-v0.1 "Publishing to skills.sh" framing.
- `demo/README.md` was still using `REVCAT_API_KEY=sk_...` (removed in v0.4). Updated to the v0.4 equivalent.

After this PR, a final grep across every `.md` in the repo for the old patterns (`secret_key`, `sk_`, `--secret-key`, `REVCAT_API_KEY`, `partner-tier`, `auth_type`) returns only the intentional v0.3 migration heading in `revcat-troubleshooting` (matches the literal error string users search for).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->