### PR TITLE
docs/commands/index: align overview rows with real CLI surface

### DIFF
--- a/docs/src/content/docs/commands/index.md
+++ b/docs/src/content/docs/commands/index.md
@@ -12,7 +12,7 @@ revcat is organized by RevenueCat resource: customers, offerings, paywalls, etc.
 | [`projects`](/commands/projects/) | `list`, `view` | - |
 | [`apps`](/commands/apps/) | `list`, `view`, `public-keys`, `storekit-config` | - |
 | [`entitlements`](/commands/entitlements/) | `list`, `view`, `products` | `create`, `update`, `delete`, `archive`, `unarchive`, `attach`, `detach` |
-| [`offerings`](/commands/offerings/) | `list`, `view` | `create`, `update`, `delete`, `archive`, `unarchive`, `set-current` |
+| [`offerings`](/commands/offerings/) | `list`, `view`, `preview` | `create`, `update`, `delete`, `archive`, `unarchive`, `set-current` |
 | [`packages`](/commands/packages/) | `list`, `view`, `products` | `create`, `update`, `delete`, `attach`, `detach` |
 | [`products`](/commands/products/) | `list`, `view` | `create`, `update`, `delete`, `archive`, `unarchive`, `push-to-store` |
 | [`paywalls`](/commands/paywalls/) | `list`, `view` | `create`, `delete` |
@@ -21,7 +21,7 @@ revcat is organized by RevenueCat resource: customers, offerings, paywalls, etc.
 
 | Group | Reads | Writes |
 | --- | --- | --- |
-| [`subscribers`](/commands/subscribers/) | `info`, `list`, `attributes`, `invoices`, `vc-balance` | `create`, `delete`, `grant`, `revoke`, `refund`, `transfer`, `override-offering`, `restore-google-play`, `vc-tx`, `vc-set-balance` |
+| [`subscribers`](/commands/subscribers/) | `info`, `list`, `attributes`, `invoices` | `create`, `delete`, `grant`, `revoke`, `refund`, `transfer` |
 | [`subscriptions`](/commands/subscriptions/) | `view`, `transactions`, `entitlements`, `management-url`, `search` | `cancel`, `refund` |
 | [`purchases`](/commands/purchases/) | `view`, `entitlements`, `search` | `refund` |
 | [`invoices`](/commands/invoices/) | `view` | - |


### PR DESCRIPTION
Found in a content-level audit (the regex sweep last round only caught auth-term staleness).

The `subscribers` row listed five subcommands that don't exist in the CLI: `vc-balance`, `vc-tx`, `vc-set-balance`, `override-offering`, `restore-google-play`. They were never wrapped because v2 doesn't expose the underlying endpoints (`api-coverage.md` already documents them as removed in v0.1.2).

Also added the missing `preview` subcommand to the `offerings` reads column.

Verified every other row by running `revcat <group> --help` against the v0.4 binary. All other rows match.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->