### PR TITLE
Add revcat apps create / update / delete

### DIFF
--- a/commands/apps/apps.go
+++ b/commands/apps/apps.go
@@ -3,20 +3,29 @@ package apps
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
 
+	"github.com/akshitkrnagpal/revcat/internal/api"
 	"github.com/akshitkrnagpal/revcat/internal/cliutil"
 	"github.com/akshitkrnagpal/revcat/internal/output"
 )
 
 var Cmd = &cobra.Command{
 	Use:   "apps",
-	Short: "Inspect RevenueCat apps (per-platform inside a project)",
+	Short: "Manage RevenueCat apps (per-platform inside a project)",
 	Long: `Each project has one app per platform/storefront (one for iOS, one for
-Android, etc.). App create/update/delete needs a partner-tier key and is
-not exposed here; this group is read-only for normal secret keys.`,
+Android, etc.).
+
+Read commands ` + "`list`, `view`, `public-keys`, `storekit-config`" + ` work on
+any app. Write commands ` + "`create`, `update`, `delete`" + ` use the v2 app
+endpoints; pass ` + "`--file <path>`" + ` for any non-trivial body since the
+schema is wide and storefront-specific.`,
 }
 
 func init() {
@@ -24,6 +33,9 @@ func init() {
 	Cmd.AddCommand(viewCmd)
 	Cmd.AddCommand(keysCmd)
 	Cmd.AddCommand(storeKitCmd)
+	Cmd.AddCommand(createCmd)
+	Cmd.AddCommand(updateCmd)
+	Cmd.AddCommand(deleteCmd)
 }
 
 var listCmd = &cobra.Command{
@@ -127,6 +139,194 @@ var storeKitCmd = &cobra.Command{
 		}
 		return output.JSON(cfg)
 	},
+}
+
+var (
+	createName    string
+	createType    string
+	createBundle  string
+	createPackage string
+	createFile    string
+
+	updateName string
+	updateFile string
+
+	deleteYes bool
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create an app under the active project",
+	Long: `Create a new app. v2's app body is discriminated by --type and the
+shape varies per storefront. For the common cases revcat takes
+shortcut flags:
+
+  --type app_store    --bundle <com.acme.app>
+  --type play_store   --package <com.acme.app>
+  --type amazon       --package <com.acme.app>
+
+Anything more (Stripe, rc_billing, paddle, roku, mac_app_store, or any
+optional fields like a shared_secret) needs --file <path.json>.
+
+Examples:
+    revcat apps create --type app_store --bundle com.acme.app --name "Acme iOS"
+    revcat apps create --file ./apps/new-stripe.json
+    revcat apps create --file - <<< '{"name":"Web","type":"stripe","stripe":{"stripe_account_id":"acct_..."}}'`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var body map[string]any
+		switch {
+		case createFile != "":
+			b, err := cliutil.LoadJSON(createFile)
+			if err != nil {
+				return err
+			}
+			body = b
+		case createType != "":
+			name := strings.TrimSpace(createName)
+			if name == "" {
+				return errors.New("--name is required when using shortcut flags (or pass --file)")
+			}
+			body = map[string]any{"name": name, "type": createType}
+			switch createType {
+			case "app_store", "mac_app_store":
+				if createBundle == "" {
+					return fmt.Errorf("--bundle is required for type %q", createType)
+				}
+				body[createType] = map[string]any{"bundle_id": createBundle}
+			case "play_store", "amazon":
+				if createPackage == "" {
+					return fmt.Errorf("--package is required for type %q", createType)
+				}
+				body[createType] = map[string]any{"package_name": createPackage}
+			default:
+				return fmt.Errorf("--type %q has no shortcut; pass --file with the full body", createType)
+			}
+		default:
+			return errors.New("pass --type with --bundle/--package, or --file with the full v2 body")
+		}
+
+		client, _, err := cliutil.Client(cmd)
+		if err != nil {
+			return err
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+		defer cancel()
+		a, err := client.CreateApp(ctx, body)
+		if err != nil {
+			return err
+		}
+		if output.IsJSON() {
+			return output.JSON(a)
+		}
+		return printApp(a)
+	},
+}
+
+var updateCmd = &cobra.Command{
+	Use:   "update <app_id>",
+	Short: "Update an app",
+	Long: `Update an existing app. Pass --name to rename, or --file <path.json>
+for a full v2 body (everything except 'type'). Send a nested field as
+null in the JSON body to clear it (e.g. {"app_store":{"shared_secret":null}}).
+
+Examples:
+    revcat apps update app_abc --name "Acme iOS (renamed)"
+    revcat apps update app_abc --file ./patch.json`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var body map[string]any
+		if updateFile != "" {
+			b, err := cliutil.LoadJSON(updateFile)
+			if err != nil {
+				return err
+			}
+			body = b
+		} else if updateName != "" {
+			body = map[string]any{"name": updateName}
+		} else {
+			return errors.New("pass --name or --file")
+		}
+
+		client, _, err := cliutil.Client(cmd)
+		if err != nil {
+			return err
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+		defer cancel()
+		a, err := client.UpdateApp(ctx, args[0], body)
+		if err != nil {
+			return err
+		}
+		if output.IsJSON() {
+			return output.JSON(a)
+		}
+		return printApp(a)
+	},
+}
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete <app_id>",
+	Short: "Delete an app (hard delete)",
+	Long: `Delete an app. This is a hard delete and can return 409 if the app
+has dependent resources (offerings, products, etc.). Prefer to drain
+those first.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !deleteYes {
+			var ok bool
+			if err := survey.AskOne(&survey.Confirm{
+				Message: fmt.Sprintf("Permanently delete app %q? This cannot be undone.", args[0]),
+				Default: false,
+			}, &ok); err != nil {
+				return err
+			}
+			if !ok {
+				return errors.New("aborted")
+			}
+		}
+
+		client, _, err := cliutil.Client(cmd)
+		if err != nil {
+			return err
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+		defer cancel()
+		if err := client.DeleteApp(ctx, args[0]); err != nil {
+			return err
+		}
+		output.Success("deleted app %q", args[0])
+		return nil
+	},
+}
+
+func init() {
+	createCmd.Flags().StringVar(&createName, "name", "", "App name")
+	createCmd.Flags().StringVar(&createType, "type", "", "Storefront type: app_store | play_store | amazon | mac_app_store (use --file for stripe / rc_billing / paddle / roku)")
+	createCmd.Flags().StringVar(&createBundle, "bundle", "", "Bundle id (app_store / mac_app_store)")
+	createCmd.Flags().StringVar(&createPackage, "package", "", "Package name (play_store / amazon)")
+	createCmd.Flags().StringVar(&createFile, "file", "", "Path to a JSON file with the full v2 body (use - for stdin)")
+
+	updateCmd.Flags().StringVar(&updateName, "name", "", "Rename the app")
+	updateCmd.Flags().StringVar(&updateFile, "file", "", "Path to a JSON file with the v2 update body (use - for stdin)")
+
+	deleteCmd.Flags().BoolVarP(&deleteYes, "confirm", "y", false, "Skip the confirmation prompt")
+}
+
+func printApp(a *api.App) error {
+	bundleOrPkg := a.BundleID
+	bundleLabel := "bundle_id"
+	if bundleOrPkg == "" {
+		bundleOrPkg = a.PackageName
+		bundleLabel = "package_name"
+	}
+	rows := [][]any{
+		{"id", a.ID},
+		{"name", a.Name},
+		{"platform", a.Type},
+		{bundleLabel, dash(bundleOrPkg)},
+		{"created", formatTime(a.CreatedAt)},
+	}
+	return output.Table([]string{"field", "value"}, rows)
 }
 
 func formatTime(unix int64) string {

--- a/docs/src/content/docs/commands/apps.md
+++ b/docs/src/content/docs/commands/apps.md
@@ -1,9 +1,9 @@
 ---
 title: apps
-description: Inspect RevenueCat apps (per-platform inside a project).
+description: Manage RevenueCat apps (per-platform inside a project).
 ---
 
-Each project has one app per platform/storefront (one for iOS, one for Android, etc.). App create / update / delete isn't exposed by the v2 API revcat targets; this group is read-only.
+Each project has one app per platform/storefront (one for iOS, one for Android, etc.). v2 exposes the full lifecycle: create, update, delete, plus reads.
 
 ## Subcommands
 
@@ -13,8 +13,11 @@ Each project has one app per platform/storefront (one for iOS, one for Android, 
 | `apps view <id>` | Show one app |
 | `apps public-keys <app_id>` | List the public SDK keys for an app |
 | `apps storekit-config <app_id>` | Print the StoreKit configuration for an iOS app (raw JSON) |
+| `apps create` | Create an app (`--type` shortcut for the common platforms, `--file` for the rest) |
+| `apps update <app_id>` | Update an app (POST at the same path as GET; `--name` shortcut, `--file` for arbitrary fields) |
+| `apps delete <app_id>` | Delete an app (hard delete; can 409 if dependent resources exist) |
 
-## Examples
+## Read examples
 
 ```sh
 revcat apps list
@@ -22,3 +25,52 @@ revcat apps view app_abc123
 revcat apps public-keys app_abc123
 revcat apps storekit-config app_abc123 | jq .
 ```
+
+## Create
+
+The v2 body is discriminated by `type`. Shortcut flags cover the most common platforms; for everything else pass `--file`.
+
+```sh
+# iOS
+revcat apps create --type app_store --bundle com.acme.app --name "Acme iOS"
+
+# Android
+revcat apps create --type play_store --package com.acme.app --name "Acme Android"
+
+# Anything else (Stripe, rc_billing, paddle, roku, mac_app_store, or app_store
+# with optional shared_secret / App Store Connect API key, etc.)
+revcat apps create --file ./new-stripe.json
+
+# stdin
+echo '{"name":"Web","type":"stripe","stripe":{"stripe_account_id":"acct_..."}}' \
+  | revcat apps create --file -
+```
+
+## Update
+
+`v2` uses `POST` (not `PATCH`) at `/v2/projects/{project_id}/apps/{app_id}` for updates. revcat does the right thing under the hood.
+
+```sh
+# Rename
+revcat apps update app_abc --name "Acme iOS (renamed)"
+
+# Patch arbitrary fields - send any nested field as null in the JSON to clear it
+revcat apps update app_abc --file ./patch.json
+```
+
+Sample `patch.json` to clear a stored shared_secret:
+
+```json
+{ "app_store": { "shared_secret": null } }
+```
+
+## Delete
+
+Hard delete. Confirm prompt in interactive mode; pass `-y/--confirm` to skip.
+
+```sh
+revcat apps delete app_abc           # prompts
+revcat apps delete app_abc --confirm # skips prompt (CI / scripts)
+```
+
+If the app has dependent resources (offerings, products, etc.) the API returns 409. Drain those first or back out the dependents in the dashboard.

--- a/docs/src/content/docs/commands/index.md
+++ b/docs/src/content/docs/commands/index.md
@@ -10,7 +10,7 @@ revcat is organized by RevenueCat resource: customers, offerings, paywalls, etc.
 | Group | Reads | Writes |
 | --- | --- | --- |
 | [`projects`](/commands/projects/) | `list`, `view` | `create` |
-| [`apps`](/commands/apps/) | `list`, `view`, `public-keys`, `storekit-config` | - |
+| [`apps`](/commands/apps/) | `list`, `view`, `public-keys`, `storekit-config` | `create`, `update`, `delete` |
 | [`entitlements`](/commands/entitlements/) | `list`, `view`, `products` | `create`, `update`, `delete`, `archive`, `unarchive`, `attach`, `detach` |
 | [`offerings`](/commands/offerings/) | `list`, `view`, `preview` | `create`, `update`, `delete`, `archive`, `unarchive`, `set-current` |
 | [`packages`](/commands/packages/) | `list`, `view`, `products` | `create`, `update`, `delete`, `attach`, `detach` |

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -147,6 +147,65 @@ func (c *Client) GetAppRaw(ctx context.Context, appID string) (*App, json.RawMes
 	return &a, raw, nil
 }
 
+// CreateApp creates a new app under the active project.
+//
+// v2: POST /v2/projects/{project_id}/apps,
+// scope project_configuration:apps:read_write.
+//
+// The body is discriminated by `type`. revcat passes through whatever
+// the caller assembles so we don't have to track every storefront's
+// nested-config shape (it's wide). The minimum body for the common
+// platforms:
+//
+//   - app_store:    {"name":"...","type":"app_store","app_store":{"bundle_id":"com.acme.app"}}
+//   - play_store:   {"name":"...","type":"play_store","play_store":{"package_name":"com.acme.app"}}
+//   - amazon:       {"name":"...","type":"amazon","amazon":{"package_name":"com.acme.app"}}
+//   - stripe:       {"name":"...","type":"stripe","stripe":{"stripe_account_id":"acct_..."}}
+//   - rc_billing:   {"name":"...","type":"rc_billing","rc_billing":{...optional fields}}
+//
+// Returns the created App.
+func (c *Client) CreateApp(ctx context.Context, body map[string]any) (*App, error) {
+	if err := c.requireProject(); err != nil {
+		return nil, err
+	}
+	var out App
+	if err := c.Do(ctx, "POST", c.projectPath("/apps"), body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpdateApp updates an existing app. v2 uses POST (not PATCH) at the
+// same path as GET. Body is the same shape as CreateApp but without
+// `type`, and all fields optional. Send a nested field as `null` to
+// clear it (e.g. {"app_store":{"shared_secret":null}}).
+//
+// v2: POST /v2/projects/{project_id}/apps/{app_id},
+// scope project_configuration:apps:read_write.
+func (c *Client) UpdateApp(ctx context.Context, appID string, body map[string]any) (*App, error) {
+	if err := c.requireProject(); err != nil {
+		return nil, err
+	}
+	var out App
+	path := c.projectPath("/apps/" + url.PathEscape(appID))
+	if err := c.Do(ctx, "POST", path, body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// DeleteApp deletes an app. Hard delete; can return 409 if the app
+// has dependent resources (offerings, products, etc.).
+//
+// v2: DELETE /v2/projects/{project_id}/apps/{app_id},
+// scope project_configuration:apps:read_write.
+func (c *Client) DeleteApp(ctx context.Context, appID string) error {
+	if err := c.requireProject(); err != nil {
+		return err
+	}
+	return c.Do(ctx, "DELETE", c.projectPath("/apps/"+url.PathEscape(appID)), nil, nil)
+}
+
 // ListPublicAPIKeys returns the SDK-side keys for an app.
 func (c *Client) ListPublicAPIKeys(ctx context.Context, appID string) ([]PublicAPIKey, error) {
 	if err := c.requireProject(); err != nil {


### PR DESCRIPTION
Wraps the three v2 endpoints we left wrap-pending in #36:

- `POST /v2/projects/{id}/apps` → `apps create`
- `POST /v2/projects/{id}/apps/{id}` → `apps update` (note: v2 uses POST, not PATCH, at the same path as GET)
- `DELETE /v2/projects/{id}/apps/{id}` → `apps delete`

Scope: `project_configuration:apps:read_write`.

## Create

Shortcut flags for the common platforms, `--file` for everything else (the v2 body is discriminated by `type` and the nested-config shape varies per storefront — too wide to model with flags).

```sh
revcat apps create --type app_store --bundle com.acme.app --name "Acme iOS"
revcat apps create --type play_store --package com.acme.app --name "Acme Android"
revcat apps create --file ./stripe.json
```

## Update

`--name` shortcut for renames, `--file` for any other field. Send a nested field as `null` in the JSON to clear it.

```sh
revcat apps update app_abc --name "Acme iOS (renamed)"
revcat apps update app_abc --file ./patch.json
```

## Delete

Hard delete. Confirm prompt by default; `-y/--confirm` to skip.

```sh
revcat apps delete app_abc           # prompts
revcat apps delete app_abc --confirm # CI / scripts
```

v2 returns 409 if the app has dependent resources (offerings, products, etc.). Drain those first.

## Test plan

- [ ] `apps create --type app_store --bundle com.smoke.test --name smoke` returns 201 with an app id.
- [ ] `apps update <id> --name renamed` returns 200 with the new name.
- [ ] `apps delete <id>` (with confirm) returns 200 `DeletedObject`.
- [ ] `apps create --type stripe` errors out instructing to use `--file`.
- [ ] `apps update <id>` without flags errors with "pass --name or --file".

Part 2 of three. Collaborators list next.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->