### PR TITLE
Add revcat collaborators list

### DIFF
--- a/commands/collaborators/collaborators.go
+++ b/commands/collaborators/collaborators.go
@@ -1,0 +1,81 @@
+// Package collaborators holds `revcat collaborators ...` - read access
+// to project membership.
+package collaborators
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/akshitkrnagpal/revcat/internal/cliutil"
+	"github.com/akshitkrnagpal/revcat/internal/output"
+)
+
+// Cmd is the parent of the collaborators subcommands. Mounted at root
+// in commands/root.go.
+var Cmd = &cobra.Command{
+	Use:     "collaborators",
+	Aliases: []string{"members"},
+	Short:   "Inspect project collaborators (members)",
+	Long: `List the people with access to the active RevenueCat project.
+
+Read-only: v2 doesn't expose invite / role-change / remove via REST.
+Manage membership in the dashboard.`,
+}
+
+func init() {
+	Cmd.AddCommand(listCmd)
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List collaborators on the active project",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, _, err := cliutil.Client(cmd)
+		if err != nil {
+			return err
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+		defer cancel()
+		members, err := client.ListCollaborators(ctx)
+		if err != nil {
+			return err
+		}
+		rows := make([][]any, 0, len(members))
+		for _, m := range members {
+			rows = append(rows, []any{
+				m.ID,
+				dash(m.Name),
+				m.Email,
+				dash(m.Role),
+				accepted(m.AcceptedAt),
+				yesNo(m.HasMFA),
+			})
+		}
+		return output.Table([]string{"id", "name", "email", "role", "accepted", "mfa"}, rows)
+	},
+}
+
+func dash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// accepted converts a nullable accepted_at unix-ms into a date string
+// or "pending" if the invite has not been accepted yet.
+func accepted(ms int64) string {
+	if ms == 0 {
+		return "pending"
+	}
+	return time.UnixMilli(ms).UTC().Format("2006-01-02")
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -6,6 +6,7 @@ import (
 
 	appscmd "github.com/akshitkrnagpal/revcat/commands/apps"
 	auditlogscmd "github.com/akshitkrnagpal/revcat/commands/auditlogs"
+	collaboratorscmd "github.com/akshitkrnagpal/revcat/commands/collaborators"
 	authcmd "github.com/akshitkrnagpal/revcat/commands/auth"
 	doctorcmd "github.com/akshitkrnagpal/revcat/commands/doctor"
 	entitlementscmd "github.com/akshitkrnagpal/revcat/commands/entitlements"
@@ -88,6 +89,7 @@ func init() {
 
 	rootCmd.AddCommand(appscmd.Cmd)
 	rootCmd.AddCommand(auditlogscmd.Cmd)
+	rootCmd.AddCommand(collaboratorscmd.Cmd)
 	rootCmd.AddCommand(authcmd.Cmd)
 	rootCmd.AddCommand(doctorcmd.Cmd)
 	rootCmd.AddCommand(entitlementscmd.Cmd)

--- a/docs/src/content/docs/commands/collaborators.md
+++ b/docs/src/content/docs/commands/collaborators.md
@@ -1,0 +1,37 @@
+---
+title: collaborators
+description: Inspect project collaborators (members).
+---
+
+List the people with access to the active RevenueCat project.
+
+Read-only: v2 doesn't expose invite / role-change / remove via REST. Manage membership in the [dashboard](https://app.revenuecat.com).
+
+## Subcommands
+
+| Command | Description |
+| --- | --- |
+| `collaborators list` | List collaborators on the active project |
+
+## Examples
+
+```sh
+revcat collaborators list
+revcat collaborators list --output json | jq '.[] | select(.role == "admin")'
+
+# Spot pending invites
+revcat collaborators list --output json | jq '.[] | select(.accepted_at == null)'
+```
+
+Aliases: `members`.
+
+## Output
+
+Table columns:
+
+- `id` — collaborator id
+- `name` — display name (`-` if the invite hasn't been accepted)
+- `email`
+- `role` — free-form per v2 (commonly `admin`, `developer`, `billing`, `viewer`)
+- `accepted` — invite acceptance date, or `pending` if the user hasn't accepted yet
+- `mfa` — whether the collaborator has multi-factor auth enabled

--- a/docs/src/content/docs/commands/index.md
+++ b/docs/src/content/docs/commands/index.md
@@ -33,6 +33,7 @@ revcat is organized by RevenueCat resource: customers, offerings, paywalls, etc.
 | [`metrics`](/commands/metrics/) | `overview` | - |
 | [`charts`](/commands/charts/) | `get`, `options` | - |
 | [`audit-logs`](/commands/audit-logs/) | `list` | - |
+| [`collaborators`](/commands/collaborators/) | `list` | - |
 
 ## Integrations
 

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -175,3 +175,28 @@ func (c *Client) ListAuditLogs(ctx context.Context) ([]AuditLogEntry, error) {
 	}
 	return paginate[AuditLogEntry](ctx, c, c.projectPath("/audit_logs"))
 }
+
+// Collaborator is a member of a RevenueCat project.
+//
+// `name` is nullable on the v2 API (returned as null for invitees who
+// haven't completed signup). `accepted_at` is also nullable - null
+// means a pending invite. `role` is free-form per the v2 spec; common
+// values include "admin", "developer", "billing", "viewer".
+type Collaborator struct {
+	ID         string `json:"id"`
+	Name       string `json:"name,omitempty"`
+	Email      string `json:"email"`
+	Role       string `json:"role,omitempty"`
+	AcceptedAt int64  `json:"accepted_at,omitempty"`
+	HasMFA     bool   `json:"has_mfa"`
+}
+
+// ListCollaborators pages through every collaborator on the active
+// project. v2: GET /v2/projects/{project_id}/collaborators,
+// scope project_configuration:collaborators:read.
+func (c *Client) ListCollaborators(ctx context.Context) ([]Collaborator, error) {
+	if err := c.requireProject(); err != nil {
+		return nil, err
+	}
+	return paginate[Collaborator](ctx, c, c.projectPath("/collaborators"))
+}


### PR DESCRIPTION
Wraps `GET /v2/projects/{id}/collaborators` (scope `project_configuration:collaborators:read`).

```sh
revcat collaborators list
revcat collaborators list --output json | jq '.[] | select(.role == "admin")'
revcat collaborators list --output json | jq '.[] | select(.accepted_at == null)'  # pending invites
```

Aliases: `members`. Read-only — v2 doesn't expose invite / role-change / remove via REST, so write commands stay in the dashboard.

## Output

Table columns: `id`, `name` (`-` if invite hasn't been accepted), `email`, `role` (free-form per v2; commonly `admin`, `developer`, `billing`, `viewer`), `accepted` (date or `pending`), `mfa` (yes/no).

## What changed

- `internal/api/projects.go`: new `Collaborator` struct + `ListCollaborators` paginated helper.
- `commands/collaborators/collaborators.go`: new package with `listCmd`.
- `commands/root.go`: register the new top-level command group.
- `docs/commands/collaborators.md`: new docs page.
- `docs/commands/index.md`: new row under "Activity".

## Test plan

- [ ] `revcat collaborators list` against a project with multiple members returns the expected rows.
- [ ] A pending invite shows `accepted: pending`.
- [ ] `--output json | jq` round-trips fine.
- [ ] `revcat members list` (alias) works.

Part 3 of three. After all merge: docs sweep + v0.5.0 release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->