### PR TITLE
Post-merge sweep: align docs + skills with new commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ revcat synthesizes a virtual profile, refreshes tokens in-memory, no keychain or
 ## Command surface
 
 ```
-revcat projects           list | view
-revcat apps               list | view | public-keys | storekit-config
+revcat projects           list | view | create
+revcat apps               list | view | public-keys | storekit-config | create | update | delete
 
 revcat entitlements       list | view | create | update | delete | archive | unarchive
                           products | attach | detach
@@ -103,6 +103,7 @@ revcat publish offering   <id> [--paywall ./paywall.json] [--current] [-y] [--dr
 revcat metrics            overview
 revcat charts             get <name> | options <name>
 revcat audit-logs         list
+revcat collaborators      list
 
 revcat webhooks           list | view | create | update | delete
 revcat virtual-currencies list | view | create | update | delete | archive | unarchive

--- a/docs/src/content/docs/reference/api-coverage.md
+++ b/docs/src/content/docs/reference/api-coverage.md
@@ -10,8 +10,7 @@ Source of truth: <https://www.revenuecat.com/docs/api-v2>.
 
 ## Headline
 
-- Most v2 operations reachable with revcat's OAuth scope set are wrapped and smoke-tested.
-- A few v2 endpoints exist but aren't wrapped in revcat yet (project create, app CRUD, collaborators list). Tracked as enhancement issues.
+- Every v2 operation reachable with revcat's OAuth scope set is wrapped and smoke-tested.
 - A few endpoints don't exist on the v2 customer surface at all - documented at the bottom.
 - RC v2 has no REST events firehose; lifecycle events are webhook-delivered. revcat exposes webhook CRUD; subscribe your own endpoint with `revcat webhooks create`.
 
@@ -21,9 +20,9 @@ Source of truth: <https://www.revenuecat.com/docs/api-v2>.
 
 | API operation | revcat |
 | --- | --- |
-| `GET /projects` | `revcat projects list`, `revcat auth login` (picker) |
+| `GET /projects` | `revcat projects list` |
 | `GET /projects/{id}` | `revcat projects view` |
-| `POST /projects` | v2 endpoint exists; revcat wrap pending |
+| `POST /projects` | `revcat projects create` |
 
 ### Apps
 
@@ -33,10 +32,15 @@ Source of truth: <https://www.revenuecat.com/docs/api-v2>.
 | `GET /apps/{id}` | `revcat apps view` |
 | `GET /apps/{id}/public_api_keys` | `revcat apps public-keys` |
 | `GET /apps/{id}/store_kit_config` | `revcat apps storekit-config` |
-| `POST /apps` | v2 endpoint exists; revcat wrap pending |
-| `POST /apps/{id}` (update) | v2 endpoint exists; revcat wrap pending |
-| `DELETE /apps/{id}` | v2 endpoint exists; revcat wrap pending |
-| `GET /projects/{id}/collaborators` | v2 endpoint exists; revcat wrap pending |
+| `POST /apps` | `revcat apps create` |
+| `POST /apps/{id}` (update) | `revcat apps update` |
+| `DELETE /apps/{id}` | `revcat apps delete` |
+
+### Collaborators
+
+| API operation | revcat |
+| --- | --- |
+| `GET /projects/{id}/collaborators` | `revcat collaborators list` |
 
 ### Customers
 

--- a/skills/revcat-commands/SKILL.md
+++ b/skills/revcat-commands/SKILL.md
@@ -41,11 +41,27 @@ Writes `revcat.toml` (committed: project_id + apps) and `.revcat/config.json` (g
 ```sh
 revcat projects list
 revcat projects view [<id>]                   # default: resolved project
+revcat projects create --name "My App"        # returns the new project_id
 
 revcat apps list
 revcat apps view <app_id>
 revcat apps public-keys <app_id>
 revcat apps storekit-config <app_id>          # raw JSON
+
+# Create: shortcut flags for the common platforms
+revcat apps create --type app_store --bundle com.acme.app --name "Acme iOS"
+revcat apps create --type play_store --package com.acme.app --name "Acme Android"
+# Anything else (stripe, rc_billing, paddle, roku, mac_app_store, optional fields)
+revcat apps create --file ./app.json   # or --file - for stdin
+
+# Update: --name shortcut, or --file for arbitrary fields. Send a nested
+# field as null in the JSON to clear it.
+revcat apps update <app_id> --name "renamed"
+revcat apps update <app_id> --file ./patch.json
+
+# Delete: hard delete. -y/--confirm to skip the prompt. Returns 409 if
+# the app has dependent resources.
+revcat apps delete <app_id> [-y]
 ```
 
 ## Catalog
@@ -149,6 +165,8 @@ revcat charts get <chart_name> [--start YYYY-MM-DD] [--end YYYY-MM-DD] \
     [--period day|week|month] [--filter k=v ...]
 
 revcat audit-logs list
+
+revcat collaborators list                # alias: members
 ```
 
 Valid chart names: `actives`, `actives_movement`, `actives_new`, `arr`, `churn`, `cohort_explorer`, `conversion_to_paying`, `customers_new`, `ltv_per_customer`, `ltv_per_paying_customer`, `mrr`, `mrr_movement`, `refund_rate`, `revenue`, `subscription_retention`, `subscription_status`, `trials`, `trials_movement`.

--- a/skills/revcat-getting-started/SKILL.md
+++ b/skills/revcat-getting-started/SKILL.md
@@ -67,7 +67,7 @@ When you `revcat init` inside a repo, it copies whichever profile is active at t
 
 Resources (CRUD + actions):
 
-- `projects` (list/view), `apps` (list/view + public-keys + storekit-config)
+- `projects` (list/view/create), `apps` (list/view + public-keys + storekit-config + create/update/delete), `collaborators` (list)
 - `entitlements`, `offerings`, `packages`, `products`, `paywalls`
 - `subscribers` (customers), `subscriptions`, `purchases`, `invoices`
 - `webhooks`, `virtual-currencies`
@@ -93,11 +93,9 @@ Auth + housekeeping:
 - `--pretty` - indent JSON
 - `-v / -q / --no-color / --debug`
 
-## What revcat does NOT cover (out of scope)
+## What revcat does NOT cover
 
-- `POST /projects` (project create) - not in v2 REST
-- App CRUD - not in v2 REST
-- `GET /collaborators` - not in v2 REST
+- Project update or delete - v2 has create + list only.
 - An events firehose - RC delivers lifecycle events via webhooks, not a REST stream. Use `revcat webhooks create` to register your endpoint.
 
 ## First useful commands

--- a/skills/revcat-troubleshooting/SKILL.md
+++ b/skills/revcat-troubleshooting/SKILL.md
@@ -20,7 +20,7 @@ Logs the full request and response (with the bearer token redacted).
 The login step or any later command got 401.
 
 - The OAuth token may have been revoked (Account Security UI in the RC dashboard) or the refresh token expired. Re-run `revcat auth login`.
-- If you're trying to call something the v2 REST API doesn't expose (project create, app CRUD, collaborators), you'll see 401/403/404. Those are out of scope for revcat.
+- If you're trying to call something the v2 REST API doesn't expose (project update/delete, an events firehose), you'll see 401/403/404. Those are out of scope.
 
 ## "this profile was created under v0.3 secret-key auth"
 
@@ -121,6 +121,6 @@ If the user reaches for the dashboard for one of these, that's expected. If they
 
 ## Where revcat does NOT work
 
-- Project create, app CRUD, collaborators - not exposed by the v2 REST API.
+- Project update or delete - v2 only exposes create + list.
 - An events firehose - RC delivers lifecycle events via webhooks (`revcat webhooks`), not a REST stream.
 - Anything not in `revcat <group> --help` - revcat tracks v2; v1-only endpoints are not wrapped (see above for the curl fallback).


### PR DESCRIPTION
After PRs #37/#38/#39 wrapped the v2 endpoints we'd flagged as wrap-pending in #36:

- `api-coverage.md`: project create, app CRUD, collaborators list rows now point at the real revcat commands. Added a new `Collaborators` section. Headline tightened to "every v2 operation reachable with revcat's OAuth scope set is wrapped."
- `README` command surface: projects gains `create`, apps gains `create | update | delete`, new `collaborators list` row.
- `skills/revcat-commands`: new flag shapes for projects create / apps CRUD; collaborators list under Activity.
- `skills/revcat-getting-started`: top-level command map updated; "What revcat does NOT cover" trimmed to actually-out-of-scope items (project update/delete, events firehose).
- `skills/revcat-troubleshooting`: stale wording about project create / app CRUD / collaborators removed.

Final grep across docs + skills + README + CLAUDE.md returns no remaining "wrap pending," "partner-tier," or "secret key revcat uses" hits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->