### PR TITLE
demo.tape: 5-second hero shot

### DIFF
--- a/demo/demo.tape
+++ b/demo/demo.tape
@@ -13,7 +13,7 @@
 #   - this directory has been bound to a project (cd demo && revcat init)
 #     so revcat picks up project context from ./.revcat/config.json,
 #     OR REVCAT_REFRESH_TOKEN + REVCAT_PROJECT_ID are set in the env
-#   - the bound project has an offering called "pro" (or edit below)
+#   - the bound project has an offering called "default" (or edit below)
 #####################################################################
 
 Output demo.gif
@@ -42,14 +42,14 @@ Sleep 1500ms
 # 2. Ship it. The orchestrator does both steps - PUT paywall + set
 #    offering as current - in one shot. --dry-run prints the plan so
 #    the demo is reproducible regardless of repo state.
-Type "revcat publish offering pro --paywall ./paywall.json --dry-run --confirm"
+Type "revcat publish offering default --paywall ./paywall.json --dry-run --confirm"
 Sleep 200ms
 Enter
 Sleep 2500ms
 
 # 3. Confirm. Read-only, just shows that the offering is what the SDK
 #    will see.
-Type "revcat offerings view pro"
+Type "revcat offerings view default"
 Sleep 200ms
 Enter
 Sleep 1500ms

--- a/demo/demo.tape
+++ b/demo/demo.tape
@@ -31,6 +31,7 @@ Type 'export PS1="%F{12}$ %f"' Enter
 Ctrl+L
 Show
 
+# 1. Health check. Shows OAuth source + resolved project context in one table.
 Type "revcat doctor --output table"
 Sleep 200ms
 Enter
@@ -40,7 +41,7 @@ Type "clear"
 Enter
 Sleep 200ms
 
-# Catalog read
+# 2. Catalog read.
 Type "revcat offerings list"
 Sleep 200ms
 Enter
@@ -50,17 +51,18 @@ Type "clear"
 Enter
 Sleep 200ms
 
-# Catalog: entitlements
-Type "revcat entitlements list"
+# 3. Project membership - new in v0.5.
+Type "revcat collaborators list"
 Sleep 200ms
 Enter
-Sleep 2.5s
+Sleep 3s
 
 Type "clear"
 Enter
 Sleep 200ms
 
-# The verb-orchestrator: dry-run a paywall publish.
+# 4. The verb-orchestrator: dry-run a paywall publish.
+#    Sets the offering as current AND PUTs the paywall body in one shot.
 Type "revcat publish offering default --paywall ./paywall.json --dry-run --confirm"
 Sleep 300ms
 Enter

--- a/demo/demo.tape
+++ b/demo/demo.tape
@@ -1,5 +1,7 @@
 #####################################################################
-# revcat demo gif
+# revcat demo gif - the 5-second hero shot
+#
+# One moment of joy: ship a paywall update from the terminal.
 #
 # Regenerate with:
 #   brew install vhs
@@ -11,7 +13,7 @@
 #   - this directory has been bound to a project (cd demo && revcat init)
 #     so revcat picks up project context from ./.revcat/config.json,
 #     OR REVCAT_REFRESH_TOKEN + REVCAT_PROJECT_ID are set in the env
-#   - the bound project has at least one offering called "default"
+#   - the bound project has an offering called "pro" (or edit below)
 #####################################################################
 
 Output demo.gif
@@ -19,7 +21,7 @@ Output demo.gif
 Set Shell "zsh"
 Set FontSize 18
 Set Width 1280
-Set Height 720
+Set Height 480
 Set Theme "Catppuccin Mocha"
 Set Padding 24
 Set TypingSpeed 35ms
@@ -31,45 +33,25 @@ Type 'export PS1="%F{12}$ %f"' Enter
 Ctrl+L
 Show
 
-# 1. Health check. Shows OAuth source + resolved project context in one table.
-Type "revcat doctor --output table"
+# 1. Frame the input. Show the paywall body that will ship.
+Type "cat paywall.json | jq"
 Sleep 200ms
 Enter
-Sleep 3s
+Sleep 1500ms
 
-Type "clear"
-Enter
-Sleep 200ms
-
-# 2. Catalog read.
-Type "revcat offerings list"
+# 2. Ship it. The orchestrator does both steps - PUT paywall + set
+#    offering as current - in one shot. --dry-run prints the plan so
+#    the demo is reproducible regardless of repo state.
+Type "revcat publish offering pro --paywall ./paywall.json --dry-run --confirm"
 Sleep 200ms
 Enter
-Sleep 3s
+Sleep 2500ms
 
-Type "clear"
-Enter
-Sleep 200ms
-
-# 3. Project membership - new in v0.5.
-Type "revcat collaborators list"
+# 3. Confirm. Read-only, just shows that the offering is what the SDK
+#    will see.
+Type "revcat offerings view pro"
 Sleep 200ms
 Enter
-Sleep 3s
+Sleep 1500ms
 
-Type "clear"
-Enter
-Sleep 200ms
-
-# 4. The verb-orchestrator: dry-run a paywall publish.
-#    Sets the offering as current AND PUTs the paywall body in one shot.
-Type "revcat publish offering default --paywall ./paywall.json --dry-run --confirm"
-Sleep 300ms
-Enter
-Sleep 4s
-
-Type "clear"
-Enter
-Sleep 200ms
-
-Sleep 800ms
+Sleep 600ms

--- a/demo/demo.tape
+++ b/demo/demo.tape
@@ -8,9 +8,10 @@
 #
 # Assumes:
 #   - revcat is on $PATH (brew install akshitkrnagpal/tap/revcat)
-#   - an active profile exists in your keychain (revcat auth login ...)
-#   - the active profile points at a project that has at least one
-#     offering called "default"
+#   - this directory has been bound to a project (cd demo && revcat init)
+#     so revcat picks up project context from ./.revcat/config.json,
+#     OR REVCAT_REFRESH_TOKEN + REVCAT_PROJECT_ID are set in the env
+#   - the bound project has at least one offering called "default"
 #####################################################################
 
 Output demo.gif


### PR DESCRIPTION
Replaces the multi-command feature tour with one moment of joy: ship a paywall update from the terminal.

## Sequence (~7s)

1. `cat paywall.json | jq` — frame the input (1.5s)
2. `revcat publish offering pro --paywall ./paywall.json --dry-run --confirm` — the orchestrator (2.5s)
3. `revcat offerings view pro` — verify (1.5s)

## Why

Charm.sh / Linear / Hashimoto-era launches all win on visceral 5-second moments, not breadth. The previous 30-second tour buried the killer feature ("one command, one deploy") under three reads. README hero gifs need to make the viewer go "oh." in 5 seconds — anything longer is a tutorial, not a pitch.

## Cosmetic

- Height bumped 720 → 480 since the new flow doesn't need that much vertical space and a slimmer gif looks tighter on the README.
- Comment header at top updated to reflect the v0.4+ project context model (was already in this PR's previous commit).

## Gif not regenerated

`demo.gif` is unchanged by this PR. Run `cd demo && vhs demo.tape` to refresh it before any marketing push.