### PR TITLE
skills: fix revcat-troubleshooting frontmatter so skills.sh picks it up

### DIFF
--- a/skills/revcat-troubleshooting/SKILL.md
+++ b/skills/revcat-troubleshooting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: revcat-troubleshooting
-description: Use when a revcat command fails or shows an error. Common errors: 401 unauthorized, no profile, no project_id, 404 customer/subscription, dashboard-only endpoints, paywall PUT failures, ndjson parsing, Test Store quirks, v1-only endpoints, v0.3-to-v0.4 upgrade paths, toml/local mismatch. Triggers on revcat error output, "revcat doesn't work", "command not supported", "atob error", "endpoint missing".
+description: Use when a revcat command fails or shows an error (401 unauthorized, no profile, no project_id, 404 customer/subscription, dashboard-only endpoints, paywall PUT failures, ndjson parsing, Test Store quirks, v1-only endpoints, v0.3-to-v0.4 upgrade paths, toml/local mismatch). Triggers on revcat error output, "revcat doesn't work", "command not supported", "atob error", "endpoint missing".
 ---
 
 # revcat - troubleshooting


### PR DESCRIPTION
skills.sh's CLI was finding only 3 of the 4 revcat skills because the YAML frontmatter on `revcat-troubleshooting` had `Common errors: 401 ...` in the description — that internal `: ` is a YAML key-value separator and the parser silently dropped the skill.

Replaced with parentheses to preserve readability without the colon-space pattern.

Verified by reading the description back: same meaning, no internal colons, valid YAML.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->