### PR TITLE
QoL: ldflags-injected build metadata + Makefile help + RELEASING.md

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,6 +17,8 @@ builds:
     ldflags:
       - -s -w
       - -X github.com/akshitkrnagpal/revcat/commands.Version={{ .Version }}
+      - -X github.com/akshitkrnagpal/revcat/commands.CommitHash={{ .ShortCommit }}
+      - -X github.com/akshitkrnagpal/revcat/commands.BuildTime={{ .Date }}
     goos:
       - darwin
       - linux

--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,57 @@
-.PHONY: build test typecheck docs-cli docs-groups docs drift-check help
+.PHONY: build install test typecheck docs-cli docs-groups docs drift-check verify help
 
-BIN := revcat
+# Build metadata. Captured at make-time so `make build` produces a
+# binary stamped with the current git ref + UTC build timestamp - same
+# shape goreleaser injects on tagged releases.
+BIN         := revcat
+PKG         := github.com/akshitkrnagpal/revcat/commands
+VERSION     ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT_HASH := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+BUILD_TIME  := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS     := -s -w \
+               -X $(PKG).Version=$(VERSION) \
+               -X $(PKG).CommitHash=$(COMMIT_HASH) \
+               -X $(PKG).BuildTime=$(BUILD_TIME)
 
-help:
-	@echo "Available targets:"
-	@echo "  make build         - go build the CLI binary"
-	@echo "  make test          - go test ./..."
-	@echo "  make typecheck     - go vet ./..."
-	@echo "  make docs-cli      - regen the canonical CLI reference page"
-	@echo "  make docs-groups   - regen per-group page headers (preserves prose"
-	@echo "                       below <!-- AUTOGEN_END --> markers)"
-	@echo "  make docs          - run docs-cli + docs-groups"
-	@echo "  make drift-check   - assert docs/skills don't reference missing commands"
-	@echo ""
-	@echo "Source-of-truth: cobra commands in commands/ are tier-1."
-	@echo "docs/, skills/, README.md are tier-3 and may drift. Run docs"
-	@echo "after any command-tree change. Run drift-check before commit."
+##@ Build
 
-build:
-	go build -o $(BIN) ./cmd/revcat
+build: ## Build the CLI binary into ./$(BIN) with build metadata baked in
+	go build -ldflags '$(LDFLAGS)' -o $(BIN) ./cmd/revcat
 
-test:
+install: ## Build + install to $$GOPATH/bin (or $$GOBIN)
+	go install -ldflags '$(LDFLAGS)' ./cmd/revcat
+
+##@ Test + lint
+
+test: ## go test ./...
 	go test ./...
 
-typecheck:
+typecheck: ## go vet ./...
 	go vet ./...
 
-docs-cli:
+drift-check: ## Assert docs/skills don't reference missing commands
+	go test ./commands/ -run TestDocsDontReferenceMissingCommands -v
+
+verify: typecheck test drift-check ## Pre-commit: typecheck + tests + drift-check
+
+##@ Docs
+
+docs-cli: ## Regenerate the canonical CLI reference page
 	go run ./scripts/gen-cli-reference
 
-docs-groups:
+docs-groups: ## Regenerate per-group page headers (preserves prose below AUTOGEN_END)
 	go run ./scripts/gen-group-docs
 
-docs: docs-cli docs-groups
+docs: docs-cli docs-groups ## Run docs-cli + docs-groups
 
-drift-check:
-	go test ./commands/ -run TestDocsDontReferenceMissingCommands -v
+##@ Help
+
+# Awk-based help. Targets followed by `## doc` get listed under the
+# section last marked with `##@ Section`.
+help: ## Print this help
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} \
+		/^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } \
+		/^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+	@echo ""
+	@echo "Source-of-truth: cobra commands in commands/ are tier-1."
+	@echo "After any command-tree change: make docs && make drift-check."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,74 @@
+# Releasing
+
+One-page runbook. Keep it current — when the steps shift, edit this file in the same PR.
+
+## Prereqs
+
+- `goreleaser` on `$PATH` (`brew install goreleaser`)
+- `gh` CLI authenticated (`gh auth status`)
+- Write access to `akshitkrnagpal/revcat` and `akshitkrnagpal/homebrew-tap`
+- Working tree on `main`, fully merged, fully pushed
+
+## Steps
+
+```sh
+# 1. Sync
+git checkout main && git pull --ff-only
+
+# 2. Verify everything still passes
+make verify          # typecheck + test + drift-check
+
+# 3. Pick the version (semver). Bug fixes -> patch (v0.5.1).
+#    New features -> minor (v0.6.0). Breaking -> major.
+VERSION=v0.5.1
+
+# 4. Add a CHANGELOG entry under "## [VERSION] - YYYY-MM-DD".
+$EDITOR CHANGELOG.md
+
+# 5. Open a CHANGELOG-only PR, merge it.
+git checkout -b changelog-$VERSION
+git add CHANGELOG.md && git commit -m "CHANGELOG: $VERSION entry"
+git push -u origin changelog-$VERSION
+gh pr create --title "CHANGELOG: $VERSION entry" --body "..."
+gh pr merge --squash --delete-branch
+
+# 6. Sync, tag, push tag
+git checkout main && git pull --ff-only
+git tag -a $VERSION -m "$VERSION: <one-line summary>"
+git push origin $VERSION
+
+# 7. Run goreleaser locally (no GH Actions release flow per repo policy)
+GITHUB_TOKEN=$(gh auth token) goreleaser release --clean
+
+# 8. Mark prerelease if alpha/beta/rc; otherwise leave as Latest
+gh release edit $VERSION --prerelease   # only for prereleases
+```
+
+## What gets published automatically
+
+- GitHub Release with binaries for darwin / linux / windows × amd64 / arm64 + `checksums.txt`
+- Homebrew tap formula at `akshitkrnagpal/homebrew-tap` is updated
+
+## Verification after release
+
+```sh
+# Brew tap users may need an explicit update on newer Homebrew
+brew update && brew upgrade revcat
+revcat version    # should print the new VERSION + commit + build time
+```
+
+## When NOT to release
+
+If commits since the last tag are docs-only, scripts-only, or Makefile-only, the binary is functionally identical. Skip the release. Batch into the next real feature.
+
+## Rollback
+
+```sh
+# Re-tag a prior commit if a release ships broken
+gh release delete $VERSION --cleanup-tag
+# Then either re-cut from a known-good commit or fix forward.
+```
+
+## Prerelease cadence
+
+Use `vX.Y.Z-alpha.N` for early access; mark prerelease so it doesn't show as Latest. Promote to `vX.Y.Z` when smoke-tested on a real project.

--- a/commands/root.go
+++ b/commands/root.go
@@ -28,8 +28,15 @@ import (
 	"github.com/akshitkrnagpal/revcat/internal/output"
 )
 
-// Version is set at build time via -ldflags.
-var Version = "0.0.1-dev"
+// Build metadata. All set at build time via -ldflags injection (see
+// the Makefile and .goreleaser.yaml). The defaults below mark a build
+// that wasn't built through either path - useful for
+// `go run ./cmd/revcat` during development.
+var (
+	Version    = "0.0.1-dev"
+	CommitHash = ""
+	BuildTime  = ""
+)
 
 // Global flags. Stored at package level so subcommands can read them via
 // the cmd.Root() ancestor without prop drilling.
@@ -116,5 +123,9 @@ func init() {
 	rootCmd.AddCommand(subscriptionscmd.Cmd)
 	rootCmd.AddCommand(virtualcurrenciescmd.Cmd)
 	rootCmd.AddCommand(webhookscmd.Cmd)
-	rootCmd.AddCommand(versioncmd.Cmd(Version))
+	rootCmd.AddCommand(versioncmd.Cmd(versioncmd.BuildInfo{
+		Version:    Version,
+		CommitHash: CommitHash,
+		BuildTime:  BuildTime,
+	}))
 }

--- a/commands/version/version.go
+++ b/commands/version/version.go
@@ -8,14 +8,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Cmd returns the `revcat version` command. Takes the version string at
-// construction so commands/root can pass through ldflags-injected values.
-func Cmd(version string) *cobra.Command {
+// BuildInfo carries the ldflags-injected metadata. Empty fields are
+// suppressed from the output so `go run ./cmd/revcat version` during
+// development stays readable.
+type BuildInfo struct {
+	Version    string
+	CommitHash string
+	BuildTime  string
+}
+
+// Cmd returns the `revcat version` command.
+func Cmd(info BuildInfo) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print revcat version and build info",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("revcat %s %s/%s %s\n", version, runtime.GOOS, runtime.GOARCH, runtime.Version())
+			fmt.Printf("revcat %s %s/%s %s\n",
+				info.Version, runtime.GOOS, runtime.GOARCH, runtime.Version())
+			if info.CommitHash != "" {
+				fmt.Printf("  commit: %s\n", info.CommitHash)
+			}
+			if info.BuildTime != "" {
+				fmt.Printf("  built:  %s\n", info.BuildTime)
+			}
 		},
 	}
 }


### PR DESCRIPTION
Three small dev-experience improvements borrowed from manusa/ai-cli.

## 1. Build metadata via ldflags

`commands.CommitHash` and `commands.BuildTime` added alongside existing `Version`. All three injected by both `make build` and goreleaser.

```
$ revcat version
revcat v0.5.0-4-ge05addc-dirty darwin/arm64 go1.26.2
  commit: e05addc
  built:  2026-05-02T13:30:42Z
```

The Makefile uses `git describe --tags --always --dirty` for VERSION, short hash for COMMIT_HASH, ISO-8601 UTC for BUILD_TIME — so local builds are stamped with the same shape goreleaser produces on tagged releases.

`commands/version/version.go` now takes a `BuildInfo` struct instead of a single string. Empty fields are suppressed from output, so `go run ./cmd/revcat version` during dev stays readable.

## 2. Self-documenting Makefile

Awk-based help target with `##@ Section` categories. `make help` prints:

```
Build
  build           Build the CLI binary into ./revcat with build metadata baked in
  install         Build + install to $GOPATH/bin (or $GOBIN)

Test + lint
  test            go test ./...
  typecheck       go vet ./...
  drift-check     Assert docs/skills don't reference missing commands
  verify          Pre-commit: typecheck + tests + drift-check
...
```

New targets:
- `install` — `go install` with ldflags injection
- `verify` — typecheck + test + drift-check, runnable as a pre-commit gate

## 3. RELEASING.md

One-page runbook. Captures the 8-step release flow (sync, verify, CHANGELOG PR, tag, goreleaser, mark prerelease) plus the 'when NOT to release' rule (binary unchanged = skip the release; batch into the next real feature).

## Verified

```
make build      # injects ldflags via local git
./revcat version    # prints commit + build time
make help       # categorized
make verify     # typecheck + test + drift-check all green
```

No CI workflow added (per repo policy).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->