### PR TITLE
Polish OAuth callback page: branded card, auto-close, dark mode

### DIFF
--- a/commands/auth/login.go
+++ b/commands/auth/login.go
@@ -74,6 +74,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	server.ProfileName = loginName
 	defer server.Close()
 
 	state, err := api.RandomState()

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html/template"
 	"io"
 	"net"
 	"net/http"
@@ -117,12 +118,18 @@ func AuthorizeURL(clientID, redirectURI string, scopes []string, state, codeChal
 // the browser to http://127.0.0.1:<port>/callback?code=...&state=... and
 // we capture the code. Cancellation via ctx.
 type LoopbackServer struct {
-	Port  int
-	URL   string // full redirect URI registered with RC
-	addr  net.Addr
-	srv   *http.Server
-	done  chan struct{}
-	got   *AuthorizationResponse
+	Port int
+	URL  string // full redirect URI registered with RC
+
+	// ProfileName is echoed in the success page. Optional - the caller
+	// (login.go) sets it after NewLoopbackServer so the user sees which
+	// profile slot was just populated.
+	ProfileName string
+
+	addr net.Addr
+	srv  *http.Server
+	done chan struct{}
+	got  *AuthorizationResponse
 }
 
 // AuthorizationResponse is the result of the redirect, parsed.
@@ -157,11 +164,13 @@ func NewLoopbackServer() (*LoopbackServer, error) {
 			ErrDesc: q.Get("error_description"),
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		if ls.got.Err != "" {
-			fmt.Fprintf(w, callbackHTML, "Authorization failed", ls.got.Err+": "+ls.got.ErrDesc)
-		} else {
-			fmt.Fprintf(w, callbackHTML, "You're signed in", "You can close this tab and return to the terminal.")
-		}
+		w.Header().Set("Cache-Control", "no-store")
+		_ = callbackTmpl.Execute(w, callbackData{
+			Success:     ls.got.Err == "",
+			ProfileName: ls.ProfileName,
+			ErrCode:     ls.got.Err,
+			ErrDesc:     ls.got.ErrDesc,
+		})
 		go func() { close(ls.done) }()
 	})
 	ls.srv = &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
@@ -184,14 +193,211 @@ func (ls *LoopbackServer) Close() {
 	_ = ls.srv.Shutdown(context.Background())
 }
 
-// callbackHTML is rendered to the browser tab after the redirect.
-const callbackHTML = `<!doctype html>
-<html><head><title>revcat auth</title>
+// callbackData drives the post-redirect HTML rendered in the user's
+// browser. Success vs error branches in the template; ProfileName is
+// echoed when set. ErrCode/ErrDesc come straight from the OAuth server
+// (RFC 6749 §4.1.2.1) and are auto-escaped by html/template.
+type callbackData struct {
+	Success     bool
+	ProfileName string
+	ErrCode     string
+	ErrDesc     string
+}
+
+// errorHint maps known OAuth error codes to a one-line hint shown
+// alongside the raw err/desc. Keeps the page actionable instead of
+// leaving the user to grep error_description for clues.
+func (d callbackData) ErrorHint() string {
+	switch d.ErrCode {
+	case "access_denied":
+		return "You clicked Deny on the authorization screen. Run `revcat auth login` again to retry."
+	case "invalid_scope", "unauthorized_client":
+		return "The OAuth client isn't authorized for the requested scope. Check --client-id or REVCAT_OAUTH_CLIENT_ID."
+	case "server_error", "temporarily_unavailable":
+		return "RevenueCat's OAuth server returned a transient error. Try `revcat auth login` again in a moment."
+	}
+	return ""
+}
+
+// callbackTmpl is the HTML rendered to the browser tab after the
+// redirect. Auto-closes after 3 seconds where the browser permits it
+// (Chrome/Edge for tabs opened by the OS launcher; Firefox blocks
+// window.close on tabs not opened by script). Falls back to an explicit
+// Close button. Honors prefers-color-scheme so it doesn't blast white
+// on a dark setup.
+var callbackTmpl = template.Must(template.New("callback").Parse(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>revcat auth</title>
 <style>
-body { font: 16px system-ui, sans-serif; max-width: 480px; margin: 80px auto; padding: 0 24px; color: #1a1a1a; }
-h1 { font-size: 22px; margin-bottom: 12px; }
-p { color: #555; line-height: 1.5; }
-</style></head><body><h1>%s</h1><p>%s</p></body></html>`
+:root {
+  --bg: #f7f7f8;
+  --card: #ffffff;
+  --fg: #0f1115;
+  --muted: #5c6370;
+  --border: #e5e7eb;
+  --accent: #4f46e5;
+  --code-bg: #f3f4f6;
+  --success: #10b981;
+  --error: #ef4444;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0b0d12;
+    --card: #14171f;
+    --fg: #e6e8ec;
+    --muted: #9ba1ad;
+    --border: #2a2f3a;
+    --accent: #818cf8;
+    --code-bg: #1c2030;
+  }
+}
+* { box-sizing: border-box; }
+html, body { height: 100%; margin: 0; }
+body {
+  font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.card {
+  width: 100%;
+  max-width: 460px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 32px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.04);
+}
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 22px;
+}
+.brand-dot {
+  width: 7px; height: 7px; border-radius: 999px;
+  background: var(--accent);
+}
+.icon {
+  width: 44px; height: 44px;
+  border-radius: 999px;
+  display: flex; align-items: center; justify-content: center;
+  margin-bottom: 16px;
+}
+.icon.success { background: rgba(16,185,129,0.14); color: var(--success); }
+.icon.error { background: rgba(239,68,68,0.12); color: var(--error); }
+.icon svg { width: 22px; height: 22px; }
+h1 {
+  font-size: 19px;
+  font-weight: 600;
+  margin: 0 0 6px;
+  letter-spacing: -0.01em;
+}
+p { color: var(--muted); margin: 0 0 6px; line-height: 1.5; }
+.next {
+  margin-top: 18px;
+  padding: 12px 14px;
+  background: var(--code-bg);
+  border-radius: 8px;
+  font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  color: var(--fg);
+  word-break: break-all;
+}
+.next .label {
+  display: block;
+  font: 11px/1 -apple-system, system-ui, sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+.errbox {
+  margin-top: 14px;
+  padding: 12px 14px;
+  background: var(--code-bg);
+  border-radius: 8px;
+  font: 12.5px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  color: var(--fg);
+  word-break: break-word;
+}
+.foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 22px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.close {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--fg);
+  padding: 6px 12px;
+  border-radius: 6px;
+  font: inherit;
+  cursor: pointer;
+}
+.close:hover { background: var(--code-bg); }
+</style>
+</head>
+<body>
+<main class="card">
+  <div class="brand"><span class="brand-dot"></span>revcat</div>
+  {{if .Success}}
+    <div class="icon success" aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12.5l4.5 4.5L19 7"/></svg>
+    </div>
+    <h1>You're signed in{{if .ProfileName}} as &ldquo;{{.ProfileName}}&rdquo;{{end}}</h1>
+    <p>You can close this tab and return to the terminal.</p>
+    <div class="next">
+      <span class="label">Next step</span>cd ~/your-repo &amp;&amp; revcat init
+    </div>
+  {{else}}
+    <div class="icon error" aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M6 6l12 12M18 6L6 18"/></svg>
+    </div>
+    <h1>Authorization failed</h1>
+    {{with .ErrorHint}}<p>{{.}}</p>{{end}}
+    <div class="errbox"><strong>{{.ErrCode}}</strong>{{if .ErrDesc}}: {{.ErrDesc}}{{end}}</div>
+  {{end}}
+  <div class="foot">
+    <span id="countdown">You can close this tab.</span>
+    <button class="close" type="button" onclick="window.close()">Close</button>
+  </div>
+</main>
+<script>
+(function () {
+  var el = document.getElementById('countdown');
+  var n = 3;
+  function tick() {
+    if (n <= 0) {
+      window.close();
+      el.textContent = 'You can close this tab.';
+      return;
+    }
+    el.textContent = 'Closing in ' + n + 's…';
+    n--;
+    setTimeout(tick, 1000);
+  }
+  tick();
+})();
+</script>
+</body>
+</html>`))
 
 // OpenBrowser tries to open the URL in the user's default browser. Best-
 // effort - if it fails, the caller should still print the URL so the


### PR DESCRIPTION
## Summary

The post-redirect HTML the user sees after authorizing was an h1 + p in system-ui, no branding, no auto-close, no dark mode. Felt like a 1995 default page. This PR ships a branded card with proper visual polish, behavior, and next-step guidance.

## What's new

- **Branded card layout** — revcat wordmark + accent dot, centered card with a subtle shadow on a soft background.
- **Success / error icon** — inline SVG checkmark / X tinted with the semantic color.
- **Profile name echo** — "You're signed in as 'work'" so the user can confirm which slot was just populated. Plumbed through a new `LoopbackServer.ProfileName` field set by `login.go`.
- **Next-step code block** on success: shows `cd ~/your-repo && revcat init` so the user knows what to type next.
- **Error hints** for common OAuth error codes (`access_denied`, `invalid_scope`, `unauthorized_client`, `server_error`, `temporarily_unavailable`). Falls back to the raw err code + description for unknown codes.
- **3-second auto-close** via `window.close()`. Works in Chrome / Edge / Safari for tabs opened by the launcher; Firefox blocks `window.close` on tabs the script didn't open, so the explicit **Close** button handles that case.
- **Dark mode** via `prefers-color-scheme: dark`.
- `Cache-Control: no-store` on the response so a back-button doesn't try to re-render after the loopback server has shut down.

## Implementation

- Replaced the inline `callbackHTML` const + `fmt.Sprintf` with an `html/template` parsed once at package init. Auto-escapes `ProfileName` / `ErrCode` / `ErrDesc` so an attacker who can influence those values can't inject HTML into the page.
- New `callbackData` type carries the render inputs; `ErrorHint()` is a method on it (template-callable).
- `LoopbackServer` gains `ProfileName` as a public field; `login.go` sets it after construction. `NewLoopbackServer` signature is unchanged, so the existing test still compiles.

## Test plan

- [x] `go test ./internal/api/... -run Loopback` — green
- [x] `go vet ./...` clean
- [x] `go test ./...` green
- [ ] Manual smoke: run `revcat auth login`, see the new page render in the browser, check both light + dark, confirm auto-close works in Chrome / Safari / Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->