### PR TITLE
Add npm distribution: revcat + 5 platform packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Output is a colored table when you're at a terminal and JSON when you're piping 
 ```sh
 brew install akshitkrnagpal/tap/revcat
 
+# or via npm (any platform)
+npm install -g revcat
+
 # or, from source (Go 1.26+)
 go install github.com/akshitkrnagpal/revcat/cmd/revcat@latest
 ```

--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Install revcat via Homebrew, go install, or a pre-built binary.
+description: Install revcat via Homebrew, npm, go install, or a pre-built binary.
 ---
 
 revcat is a single static Go binary. Install it however you prefer.
@@ -12,6 +12,14 @@ brew install akshitkrnagpal/tap/revcat
 ```
 
 The tap lives at <https://github.com/akshitkrnagpal/homebrew-tap> and is updated by every release.
+
+## npm
+
+```sh
+npm install -g revcat
+```
+
+Works on macOS / Linux / Windows on x64 and arm64 (no Windows arm64 yet). The npm package is a thin shim that picks the matching prebuilt binary via `optionalDependencies`. Useful when you already have Node in your toolchain (CI, dev containers, web monorepos) and don't want to add Homebrew or Go.
 
 ## `go install`
 

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,8 @@
+# Binaries are produced by scripts/npm-publish.mjs at release time, not
+# committed. The shim under npm/revcat/bin/ IS committed; everything
+# else is generated.
+revcat-darwin-arm64/bin/revcat
+revcat-darwin-x64/bin/revcat
+revcat-linux-arm64/bin/revcat
+revcat-linux-x64/bin/revcat
+revcat-win32-x64/bin/revcat.exe

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,50 @@
+# npm packaging
+
+revcat is distributed via npm under six packages: one main (`revcat`) plus five per-platform packages (`revcat-darwin-arm64`, `revcat-darwin-x64`, `revcat-linux-arm64`, `revcat-linux-x64`, `revcat-win32-x64`).
+
+The main package is a thin JS shim. It picks the matching platform package via `optionalDependencies` (npm skips the others using `os` + `cpu` filters) and execs the native binary.
+
+## Layout
+
+```
+npm/
+├── revcat/                  # main package — shim only, no binary
+│   ├── package.json         # optionalDependencies fans out to platforms
+│   └── bin/revcat           # JS shim, resolves the right platform pkg + execs it
+├── revcat-darwin-arm64/
+│   ├── package.json         # os: ["darwin"], cpu: ["arm64"]
+│   └── bin/revcat           # native binary, written by the publish script
+├── revcat-darwin-x64/        ditto
+├── revcat-linux-arm64/       ditto
+├── revcat-linux-x64/         ditto
+└── revcat-win32-x64/         (binary lives at bin/revcat.exe)
+```
+
+The platform `bin/<binary>` files are gitignored and produced by the publish script - the repo only commits the JS shim and the package.json metadata.
+
+## Releasing
+
+After `goreleaser release` (or local `goreleaser build --snapshot`) has produced archives in `dist/`, run:
+
+```sh
+scripts/npm-publish.mjs <version>           # e.g. 0.6.0
+scripts/npm-publish.mjs <version> --dry-run # smoke-test without publishing
+```
+
+The script:
+
+1. Extracts each platform's binary out of the matching `dist/revcat_<version>_<os>_<arch>.{tar.gz,zip}` into `npm/<pkg>/bin/`.
+2. Bumps every `package.json` to `<version>` (including the main package's `optionalDependencies` map - they stay in lockstep).
+3. Runs `npm publish --access public` on each platform package, then the main package last so its optionalDependency entries already exist on the registry by the time anyone installs `revcat`.
+
+Auth is whatever your local `~/.npmrc` provides - the script doesn't ship credentials. For a one-off CI-less release: `npm login`, then run the script.
+
+## Why not a postinstall download?
+
+The optionalDependencies pattern (esbuild, biome, swc, lefthook, turbo) avoids three classes of failure:
+
+- Corporate proxies / firewalls blocking GitHub releases
+- npm `--ignore-scripts` skipping postinstall and leaving the user with no binary
+- Offline / cached installs that can't reach the network
+
+With optionalDependencies, the binary is just an npm package - it gets the registry mirror, the lockfile pin, the cache, and the offline-install behavior for free.

--- a/npm/revcat-darwin-arm64/package.json
+++ b/npm/revcat-darwin-arm64/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "revcat-darwin-arm64",
+  "version": "0.0.0",
+  "description": "The revcat CLI binary for darwin-arm64. Installed automatically by `revcat`.",
+  "homepage": "https://github.com/akshitkrnagpal/revcat",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/akshitkrnagpal/revcat.git"
+  },
+  "license": "MIT",
+  "files": ["bin/revcat"],
+  "os": ["darwin"],
+  "cpu": ["arm64"]
+}

--- a/npm/revcat-darwin-x64/package.json
+++ b/npm/revcat-darwin-x64/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "revcat-darwin-x64",
+  "version": "0.0.0",
+  "description": "The revcat CLI binary for darwin-x64. Installed automatically by `revcat`.",
+  "homepage": "https://github.com/akshitkrnagpal/revcat",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/akshitkrnagpal/revcat.git"
+  },
+  "license": "MIT",
+  "files": ["bin/revcat"],
+  "os": ["darwin"],
+  "cpu": ["x64"]
+}

--- a/npm/revcat-linux-arm64/package.json
+++ b/npm/revcat-linux-arm64/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "revcat-linux-arm64",
+  "version": "0.0.0",
+  "description": "The revcat CLI binary for linux-arm64. Installed automatically by `revcat`.",
+  "homepage": "https://github.com/akshitkrnagpal/revcat",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/akshitkrnagpal/revcat.git"
+  },
+  "license": "MIT",
+  "files": ["bin/revcat"],
+  "os": ["linux"],
+  "cpu": ["arm64"]
+}

--- a/npm/revcat-linux-x64/package.json
+++ b/npm/revcat-linux-x64/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "revcat-linux-x64",
+  "version": "0.0.0",
+  "description": "The revcat CLI binary for linux-x64. Installed automatically by `revcat`.",
+  "homepage": "https://github.com/akshitkrnagpal/revcat",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/akshitkrnagpal/revcat.git"
+  },
+  "license": "MIT",
+  "files": ["bin/revcat"],
+  "os": ["linux"],
+  "cpu": ["x64"]
+}

--- a/npm/revcat-win32-x64/package.json
+++ b/npm/revcat-win32-x64/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "revcat-win32-x64",
+  "version": "0.0.0",
+  "description": "The revcat CLI binary for win32-x64. Installed automatically by `revcat`.",
+  "homepage": "https://github.com/akshitkrnagpal/revcat",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/akshitkrnagpal/revcat.git"
+  },
+  "license": "MIT",
+  "files": ["bin/revcat.exe"],
+  "os": ["win32"],
+  "cpu": ["x64"]
+}

--- a/npm/revcat/README.md
+++ b/npm/revcat/README.md
@@ -1,0 +1,15 @@
+# revcat
+
+The RevenueCat CLI. Run RevenueCat from the terminal instead of clicking through the dashboard.
+
+```sh
+npm install -g revcat
+revcat auth login
+revcat metrics overview
+```
+
+This is a thin npm wrapper around the native [revcat](https://github.com/akshitkrnagpal/revcat) Go binary. On install, npm picks the matching platform package (`revcat-darwin-arm64`, `revcat-linux-x64`, etc.) via `optionalDependencies` and the JS shim execs it with your argv.
+
+Supported platforms: `darwin-arm64`, `darwin-x64`, `linux-arm64`, `linux-x64`, `win32-x64`.
+
+For Homebrew, `go install`, or pre-built tarballs see the [main repo](https://github.com/akshitkrnagpal/revcat).

--- a/npm/revcat/bin/revcat
+++ b/npm/revcat/bin/revcat
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// revcat npm shim. Resolves the matching platform package
+// (revcat-<platform>-<arch>) installed via optionalDependencies and
+// execs the native binary with the user's argv + stdio.
+//
+// One file by design - the shim is part of every install, so it has to
+// be self-contained, dependency-free, and small enough to skim.
+
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+
+const SUPPORTED = {
+  "darwin-arm64": "revcat-darwin-arm64",
+  "darwin-x64":   "revcat-darwin-x64",
+  "linux-arm64":  "revcat-linux-arm64",
+  "linux-x64":    "revcat-linux-x64",
+  "win32-x64":    "revcat-win32-x64",
+};
+
+const key = `${process.platform}-${process.arch}`;
+const pkg = SUPPORTED[key];
+if (!pkg) {
+  console.error(
+    `revcat: no prebuilt binary for ${key}.\n` +
+    `Supported platforms: ${Object.keys(SUPPORTED).join(", ")}.\n` +
+    `Build from source: https://github.com/akshitkrnagpal/revcat`
+  );
+  process.exit(1);
+}
+
+const binName = process.platform === "win32" ? "revcat.exe" : "revcat";
+
+let binaryPath;
+try {
+  binaryPath = require.resolve(`${pkg}/bin/${binName}`);
+} catch (_) {
+  console.error(
+    `revcat: the ${pkg} package is not installed.\n` +
+    `This usually means npm skipped optionalDependencies. Try:\n` +
+    `  npm install ${pkg}\n` +
+    `Or reinstall revcat with optional deps enabled:\n` +
+    `  npm install --include=optional revcat`
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(binaryPath, process.argv.slice(2), {
+  stdio: "inherit",
+  windowsHide: true,
+});
+if (result.error) {
+  console.error(`revcat: failed to spawn binary: ${result.error.message}`);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/npm/revcat/package.json
+++ b/npm/revcat/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "revcat",
+  "version": "0.0.0",
+  "description": "The RevenueCat CLI - manage RevenueCat projects from the terminal",
+  "homepage": "https://github.com/akshitkrnagpal/revcat",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/akshitkrnagpal/revcat.git"
+  },
+  "bugs": "https://github.com/akshitkrnagpal/revcat/issues",
+  "license": "MIT",
+  "author": "Akshit Kr Nagpal",
+  "keywords": [
+    "revenuecat",
+    "cli",
+    "subscriptions",
+    "iap",
+    "in-app-purchases"
+  ],
+  "bin": {
+    "revcat": "bin/revcat"
+  },
+  "files": [
+    "bin/revcat"
+  ],
+  "optionalDependencies": {
+    "revcat-darwin-arm64": "0.0.0",
+    "revcat-darwin-x64": "0.0.0",
+    "revcat-linux-arm64": "0.0.0",
+    "revcat-linux-x64": "0.0.0",
+    "revcat-win32-x64": "0.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/npm-publish.mjs
+++ b/scripts/npm-publish.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Build + publish the revcat npm packages.
+//
+// Usage:
+//   scripts/npm-publish.mjs <version> [--dry-run]
+//
+// Expects goreleaser to have produced archives in dist/:
+//   dist/revcat_<version>_<os>_<arch>.tar.gz   (linux + darwin)
+//   dist/revcat_<version>_windows_<arch>.zip   (windows)
+//
+// Walks the matrix in PLATFORMS, extracts each archive into the matching
+// npm/<pkg>/bin/ dir, bumps every package.json to <version> (including
+// the main package's optionalDependencies map so versions stay in lockstep),
+// then `npm publish --access public` each platform package, and the main
+// package last (so the optionalDependency entries already exist by the time
+// someone installs revcat).
+//
+// --dry-run skips the publish step but still touches the files so you can
+// inspect the result before pushing.
+
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repo = resolve(__dirname, "..");
+const distDir = resolve(repo, "dist");
+
+const PLATFORMS = [
+  { pkg: "revcat-darwin-arm64", goos: "darwin",  goarch: "arm64", binary: "revcat" },
+  { pkg: "revcat-darwin-x64",   goos: "darwin",  goarch: "amd64", binary: "revcat" },
+  { pkg: "revcat-linux-arm64",  goos: "linux",   goarch: "arm64", binary: "revcat" },
+  { pkg: "revcat-linux-x64",    goos: "linux",   goarch: "amd64", binary: "revcat" },
+  { pkg: "revcat-win32-x64",    goos: "windows", goarch: "amd64", binary: "revcat.exe" },
+];
+
+const args = process.argv.slice(2);
+const version = args.find(a => !a.startsWith("--"));
+const dryRun = args.includes("--dry-run");
+
+if (!version || !/^\d+\.\d+\.\d+(?:-[\w.]+)?$/.test(version)) {
+  console.error("usage: scripts/npm-publish.mjs <version> [--dry-run]");
+  console.error("  version must be semver without the 'v' prefix (e.g. 0.6.0)");
+  process.exit(1);
+}
+
+console.log(`> revcat npm publish - version=${version} dry_run=${dryRun}`);
+
+// 1. extract each archive into npm/<pkg>/bin/
+for (const p of PLATFORMS) {
+  const ext = p.goos === "windows" ? "zip" : "tar.gz";
+  const archive = resolve(distDir, `revcat_${version}_${p.goos}_${p.goarch}.${ext}`);
+  const binDir = resolve(repo, "npm", p.pkg, "bin");
+  if (!existsSync(archive)) {
+    console.error(`missing archive: ${archive} - run goreleaser first`);
+    process.exit(1);
+  }
+  mkdirSync(binDir, { recursive: true });
+  if (ext === "zip") {
+    execSync(`unzip -o -j "${archive}" "${p.binary}" -d "${binDir}"`, { stdio: "inherit" });
+  } else {
+    execSync(`tar -xzf "${archive}" -C "${binDir}" "${p.binary}"`, { stdio: "inherit" });
+  }
+  chmodSync(resolve(binDir, p.binary), 0o755);
+  console.log(`  extracted ${p.pkg}/${p.binary}`);
+}
+
+// 2. bump versions in each package.json
+const bump = (relPath, mut) => {
+  const path = resolve(repo, relPath);
+  const json = JSON.parse(readFileSync(path, "utf8"));
+  mut(json);
+  writeFileSync(path, JSON.stringify(json, null, 2) + "\n");
+};
+for (const p of PLATFORMS) {
+  bump(`npm/${p.pkg}/package.json`, j => { j.version = version; });
+}
+bump("npm/revcat/package.json", j => {
+  j.version = version;
+  for (const p of PLATFORMS) j.optionalDependencies[p.pkg] = version;
+});
+console.log(`  bumped all package.json to ${version}`);
+
+// 3. publish (platform packages first, main last)
+const publish = (relPath) => {
+  const cwd = resolve(repo, relPath);
+  const cmd = "npm publish --access public" + (dryRun ? " --dry-run" : "");
+  console.log(`> ${cmd}  (in ${relPath})`);
+  execSync(cmd, { cwd, stdio: "inherit" });
+};
+for (const p of PLATFORMS) publish(`npm/${p.pkg}`);
+publish("npm/revcat");
+
+console.log("> done.");


### PR DESCRIPTION
## Summary

Distributes the revcat binary via npm using the modern **multi-package optionalDependencies** pattern (esbuild, biome, swc, lefthook, turbo). One main package (`revcat`) plus five per-platform packages (`revcat-darwin-arm64`, `revcat-darwin-x64`, `revcat-linux-arm64`, `revcat-linux-x64`, `revcat-win32-x64`).

After this lands, users get a third install option:

```sh
npm install -g revcat
```

The first npm release will be v0.6.0, matching the keyring-removal release in #48.

## How it works

- The main `revcat` package ships a tiny dependency-free JS shim at `bin/revcat`. It detects `process.platform`/`process.arch`, resolves the matching platform package via `require.resolve`, and execs the native binary with the user's argv and inherited stdio.
- Each platform package declares its `os` + `cpu` so npm only installs the matching one (others are silently skipped via `optionalDependencies`).
- All six packages stay in lockstep via `scripts/npm-publish.mjs` which bumps `version` + main's `optionalDependencies` map together.

## Why not postinstall-download?

The download-on-postinstall pattern dies on corporate proxies / firewalls, `--ignore-scripts`, and offline installs. With optionalDependencies the binary is just an npm package — it gets the registry mirror, lockfile pin, cache, and offline-install for free.

## Failure modes (both tested locally)

- **Unsupported platform** (e.g. freebsd-x64): prints the supported matrix + a link to build from source, exits 1.
- **Platform package missing** (e.g. `--no-optional`): prints the exact `npm install <pkg>` recovery command, exits 1.

## Release flow

After goreleaser produces archives in `dist/`:

```sh
scripts/npm-publish.mjs 0.6.0           # publish all six
scripts/npm-publish.mjs 0.6.0 --dry-run # smoke-test without publishing
```

The script extracts each binary from `dist/revcat_<v>_<os>_<arch>.{tar.gz,zip}`, bumps every `package.json` to `<v>` (incl. the main package's `optionalDependencies` map), then `npm publish --access public` each platform package, and the main package last (so its optional-dep entries already exist on the registry).

Auth comes from your local `~/.npmrc` — no CI / OIDC for now (would need GitHub Actions, which we're avoiding).

## Files

- `npm/revcat/` — main package: `package.json`, `bin/revcat` (JS shim), `README.md`
- `npm/revcat-<plat>/package.json` × 5 — platform packages
- `npm/.gitignore` — skip the binaries (written at release time, not committed)
- `npm/README.md` — layout + release docs
- `scripts/npm-publish.mjs` — the build-and-publish script
- `README.md`, `docs/getting-started/installation.md` — mention `npm i -g revcat`

## Name availability check

All six names are unclaimed on the npm registry as of the commit time:
`revcat`, `revcat-{darwin,linux,win32}-{arm64,x64}`.

## Test plan

- [x] Build host binary, mock the install layout, run shim → hits binary correctly, version + --help work, exit code propagates
- [x] Run shim without platform package installed → clear "missing pkg" error
- [x] Run shim with `process.platform=freebsd` → clear "unsupported platform" error
- [x] `make drift-check` clean
- [x] `go test ./...` clean
- [ ] Smoke-test the publish script with `--dry-run` once goreleaser dist/ is available (will run during the v0.6 release)
- [ ] First real publish: v0.6.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->