### PR TITLE
demo: add init.tape + customer-debug.tape

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,27 +1,30 @@
-# revcat demo
+# revcat demos
 
-`demo.gif` is the README hero. Generated from `demo.tape` via [vhs](https://github.com/charmbracelet/vhs).
+Three [vhs](https://github.com/charmbracelet/vhs) tapes, each rendering one user-facing flow. `demo.gif` is the README hero; the other two anchor specific guide pages.
+
+| Tape                    | Output                | What it shows |
+| ---                     | ---                   | --- |
+| `demo.tape`             | `demo.gif`            | Hero: ship a paywall update + set offering current with one orchestrator command. |
+| `init.tape`             | `init.gif`            | Bootstrap: `revcat init` materializes `revcat.toml` + `.revcat/config.json` so subsequent commands inherit project context. |
+| `customer-debug.tape`   | `customer-debug.gif`  | Support flow: resolve a store transaction id back to a customer, pull their state, surface the entitlements catalog. Read-only; the grant command is shown as a comment. |
 
 ## Regenerate
 
 ```sh
 brew install vhs
 
-# revcat must be on $PATH. Run `revcat auth login` once, then either
-# `revcat init` inside this directory to bind a project, or set the env
-# below for a one-off (the project must have an offering named "default").
+# revcat must be on $PATH. Either bind a project (`revcat init` in this
+# directory) so revcat picks up project context from ./.revcat/config.json,
+# OR set the env hatch for a one-off:
 export REVCAT_REFRESH_TOKEN=rtk_...
 export REVCAT_PROJECT_ID=proj_...
 
 cd demo
-vhs demo.tape          # produces demo.gif
+vhs demo.tape            # produces demo.gif
+vhs init.tape            # produces init.gif
+vhs customer-debug.tape  # produces customer-debug.gif
 ```
 
-## What's in the demo
+The `customer-debug.tape` ids are placeholders (`1000000123456789`, `app_user_demo`, `premium`). Edit them to match real ids in your test project before recording. The other two tapes work against any project that has an offering called `default` (for the hero) or just any authed credential (for init).
 
-1. `revcat doctor --output table` - quick health check, all green.
-2. `revcat offerings list` - catalog readback.
-3. `revcat entitlements list` - catalog readback.
-4. `revcat publish offering default --paywall ./paywall.json --dry-run --confirm` - the verb-orchestrator, prints the plan without mutating.
-
-`paywall.json` is a sample paywall body kept in this folder so the demo is self-contained.
+`paywall.json` is a sample paywall body kept in this folder so the hero tape is self-contained.

--- a/demo/customer-debug.tape
+++ b/demo/customer-debug.tape
@@ -1,0 +1,64 @@
+#####################################################################
+# revcat customer-debug demo - the support-ticket flow
+#
+# A user pings support: "I bought premium but the app says I don't
+# have access." The store gave them a transaction id but no app_user_id.
+# Walks the diagnostic from store id back to the customer, lists
+# entitlements, and shows the grant command commented out so this gif
+# stays read-only.
+#
+# Regenerate with:
+#   brew install vhs
+#   export REVCAT_REFRESH_TOKEN=rtk_...
+#   export REVCAT_PROJECT_ID=proj_...
+#   # Edit the placeholders below to match real ids in your TEST project:
+#   #   STORE_TX_ID, APP_USER_ID, ENTITLEMENT_ID
+#   cd demo
+#   vhs customer-debug.tape    # produces customer-debug.gif
+#####################################################################
+
+Output customer-debug.gif
+
+Set Shell "zsh"
+Set FontSize 17
+Set Width 1280
+Set Height 600
+Set Theme "Catppuccin Mocha"
+Set Padding 24
+Set TypingSpeed 35ms
+Set PlaybackSpeed 1.0
+
+Hide
+Type 'export PS1="%F{12}$ %f"' Enter
+Ctrl+L
+Show
+
+# 1. Support hands you a store transaction id. Resolve it to a sub.
+#    This is the bridge: the dashboard requires an app_user_id, but
+#    your support tooling only has the store id.
+Type "revcat subscriptions search 1000000123456789"
+Sleep 200ms
+Enter
+Sleep 2200ms
+
+# 2. Now you have the customer. Pull their state.
+Type "revcat subscribers info app_user_demo"
+Sleep 200ms
+Enter
+Sleep 2500ms
+
+# 3. Read-only entitlement list - confirms what you'd attach to.
+#    The demo stops here so it stays mutation-free.
+Type "revcat entitlements list"
+Sleep 200ms
+Enter
+Sleep 2200ms
+
+# When you're ready to actually grant goodwill access, the next step
+# is one line - shown as a comment so this gif doesn't mutate state:
+Type "# revcat subscribers grant app_user_demo premium -d 7d --confirm"
+Sleep 200ms
+Enter
+Sleep 1800ms
+
+Sleep 600ms

--- a/demo/init.tape
+++ b/demo/init.tape
@@ -1,0 +1,68 @@
+#####################################################################
+# revcat init demo - the per-repo bootstrap flow
+#
+# Shows binding a fresh repo to a RevenueCat project. Two files
+# materialize: revcat.toml (committed, project_id) and
+# .revcat/config.json (gitignored, mode 0600, credentials + project_id).
+# After this, every revcat command run in the directory inherits the
+# project context automatically.
+#
+# Regenerate with:
+#   brew install vhs
+#   export REVCAT_REFRESH_TOKEN=rtk_...
+#   export REVCAT_PROJECT_ID=proj_...
+#   cd demo
+#   vhs init.tape          # produces init.gif
+#####################################################################
+
+Output init.gif
+
+Set Shell "zsh"
+Set FontSize 18
+Set Width 1280
+Set Height 560
+Set Theme "Catppuccin Mocha"
+Set Padding 24
+Set TypingSpeed 35ms
+Set PlaybackSpeed 1.0
+
+# Setup: throwaway sandbox dir, simple prompt, project_id pre-resolved
+# from the env so the survey picker doesn't gate the recording.
+Hide
+Type 'export PS1="%F{12}$ %f"' Enter
+Type 'cd $(mktemp -d)' Enter
+Ctrl+L
+Show
+
+# 1. Empty directory. Same shape every reader's repo starts as.
+Type "ls -la"
+Sleep 200ms
+Enter
+Sleep 800ms
+
+# 2. Bind. --no-apps keeps the demo deterministic; the interactive flow
+#    would also offer to tag specific apps from the project.
+Type "revcat init --no-apps"
+Sleep 200ms
+Enter
+Sleep 2500ms
+
+# 3. Two files now exist. revcat.toml is the committed half.
+Type "ls -la"
+Sleep 200ms
+Enter
+Sleep 1200ms
+
+Type "cat revcat.toml"
+Sleep 200ms
+Enter
+Sleep 1500ms
+
+# 4. Project context is now automatic. No --project-id, no env, just
+#    works from cwd.
+Type "revcat auth status"
+Sleep 200ms
+Enter
+Sleep 2000ms
+
+Sleep 600ms


### PR DESCRIPTION
## Summary

Two new vhs tapes alongside the existing hero (`demo.tape`).

| Tape                 | Output                | What it shows |
| ---                  | ---                   | --- |
| `demo.tape`          | `demo.gif`            | (existing) Hero: ship a paywall update + set offering current with one orchestrator command. |
| `init.tape`          | `init.gif`            | The per-repo bootstrap. `revcat init --no-apps` materializes `revcat.toml` + `.revcat/config.json`; subsequent commands inherit project context from cwd. |
| `customer-debug.tape`| `customer-debug.gif`  | Support-ticket flow: store transaction id → customer state → entitlements catalog. The grant command is a typed shell comment so this gif stays read-only. |

## Why a trio

The hero shows the joy moment but doesn't anchor the two flows users actually start with: bootstrapping a repo and debugging a support ticket. Each anchors a specific guide page in the docs.

## Reproducibility

- Same vhs settings across all three (Catppuccin Mocha, zsh, `$` prompt) for visual consistency. Heights bumped to 560 / 600 on the new tapes so multi-step output isn't clipped.
- `customer-debug.tape` ids are placeholders (`1000000123456789`, `app_user_demo`, `premium`) — readers edit them to match a real test project.
- The grant step is shown as a comment, not executed, so re-running the tape doesn't extend a real customer's entitlement.

## What's NOT in this PR

- Generated `init.gif` / `customer-debug.gif`. These need test creds (`REVCAT_REFRESH_TOKEN` + `REVCAT_PROJECT_ID` for a project with offerings + at least one customer + a known store transaction id). Once you hand those over I'll record + push the gifs in a follow-up.

## Verification

- `make drift-check` clean.
- `.tape` files aren't scanned by the drift detector (it only walks `.md`), so each command was manually verified against `revcat <cmd> --help`. Notably: `subscribers grant` takes `-d/--duration` and `-y/--confirm`, no `--dry-run` (so we couldn't dry-run the grant — hence the comment-out approach).

## Merge order context

Per the broader plan: this lands second (after #47, before #48 v0.6) so main has docs + runbook + visual assets ready when v0.6 cuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->