### PR TITLE
demo: strengthen init.tape, add pipe-flow.tape for launch tweets

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,11 +1,12 @@
 # revcat demos
 
-Three [vhs](https://github.com/charmbracelet/vhs) tapes, each rendering one user-facing flow. `demo.gif` is the README hero; the other two anchor specific guide pages.
+Four [vhs](https://github.com/charmbracelet/vhs) tapes, each rendering one user-facing flow. `demo.gif` is the README hero; the others anchor specific guide pages and launch tweets.
 
 | Tape                    | Output                | What it shows |
 | ---                     | ---                   | --- |
 | `demo.tape`             | `demo.gif`            | Hero: ship a paywall update + set offering current with one orchestrator command. |
-| `init.tape`             | `init.gif`            | Bootstrap: `revcat init` materializes `revcat.toml` + `.revcat/config.json` so subsequent commands inherit project context. |
+| `init.tape`             | `init.gif`            | Bootstrap: `revcat init` materializes `revcat.toml` + `.revcat/config.json`, then a fresh shell with no env still runs project-scoped commands (the agent / sandbox proof). |
+| `pipe-flow.tape`        | `pipe-flow.gif`       | TTY flip: same command renders a colored table on a terminal, JSON the moment stdout is piped. No `--json` flag. |
 | `customer-debug.tape`   | `customer-debug.gif`  | Support flow: resolve a store transaction id back to a customer, pull their state, surface the entitlements catalog. Read-only; the grant command is shown as a comment. |
 
 ## Regenerate
@@ -22,6 +23,7 @@ export REVCAT_PROJECT_ID=proj_...
 cd demo
 vhs demo.tape            # produces demo.gif
 vhs init.tape            # produces init.gif
+vhs pipe-flow.tape       # produces pipe-flow.gif
 vhs customer-debug.tape  # produces customer-debug.gif
 ```
 

--- a/demo/init.tape
+++ b/demo/init.tape
@@ -20,7 +20,7 @@ Output init.gif
 Set Shell "zsh"
 Set FontSize 18
 Set Width 1280
-Set Height 560
+Set Height 700
 Set Theme "Catppuccin Mocha"
 Set Padding 24
 Set TypingSpeed 35ms
@@ -58,11 +58,19 @@ Sleep 200ms
 Enter
 Sleep 1500ms
 
-# 4. Project context is now automatic. No --project-id, no env, just
-#    works from cwd.
-Type "revcat auth status"
+# 4. The agent / sandbox proof. Wipe the env vars revcat used to auth
+#    in the first place, then run a project-scoped command. It still
+#    works - the walked-up .revcat/config.json carries credentials
+#    plus project_id, so any process started in this directory inherits
+#    both without touching the global file.
+Type "unset REVCAT_REFRESH_TOKEN REVCAT_PROJECT_ID"
 Sleep 200ms
 Enter
-Sleep 2000ms
+Sleep 600ms
+
+Type "revcat offerings list"
+Sleep 200ms
+Enter
+Sleep 2200ms
 
 Sleep 600ms

--- a/demo/pipe-flow.tape
+++ b/demo/pipe-flow.tape
@@ -1,0 +1,48 @@
+#####################################################################
+# revcat pipe-flow demo - the TTY-aware output flip
+#
+# Same command, two contexts. On a TTY revcat renders a colored table.
+# The moment you pipe stdout, output flips to JSON automatically. No
+# --json flag, no env knob, no opt-in. Pipe straight into jq, awk, or
+# anything that speaks JSON.
+#
+# Anchor for the "the dashboard cannot" beat in the launch tweet.
+#
+# Regenerate with:
+#   brew install vhs
+#   export REVCAT_REFRESH_TOKEN=rtk_...
+#   export REVCAT_PROJECT_ID=proj_...
+#   cd demo
+#   vhs pipe-flow.tape       # produces pipe-flow.gif
+#####################################################################
+
+Output pipe-flow.gif
+
+Set Shell "zsh"
+Set FontSize 17
+Set Width 1280
+Set Height 520
+Set Theme "Catppuccin Mocha"
+Set Padding 24
+Set TypingSpeed 35ms
+Set PlaybackSpeed 1.0
+
+Hide
+Type 'export PS1="%F{12}$ %f"' Enter
+Ctrl+L
+Show
+
+# 1. On a TTY: tables, colors, lipgloss. The default human view.
+Type "revcat offerings list"
+Sleep 200ms
+Enter
+Sleep 2200ms
+
+# 2. Pipe stdout. Same command, same flags - JSON, automatically.
+#    No --json ceremony. Compose with jq from the same prompt.
+Type "revcat offerings list | jq '.[].lookup_key'"
+Sleep 200ms
+Enter
+Sleep 2200ms
+
+Sleep 600ms


### PR DESCRIPTION
## Summary

Two tape changes mapped 1:1 to the v0.6 launch tweet thread.

### `init.tape` — strengthen tweet 2's agent angle

Old ending was `revcat auth status` (showed `source=local` but didn't *demonstrate* the inheritance). Replaced with the literal proof:

```
unset REVCAT_REFRESH_TOKEN REVCAT_PROJECT_ID
revcat offerings list
```

Wipes the env vars revcat used to auth in the first place, then runs a project-scoped command. It still works because the walked-up `.revcat/config.json` carries credentials + project_id — exactly what an AI agent or sandbox spawned in the directory experiences.

Bumped `Set Height 560 -> 700` to fit the extra two-step block.

### `pipe-flow.tape` — new, anchors tweet 3

~7-second tape, two commands:

```
revcat offerings list                          # tables on a TTY
revcat offerings list | jq '.[].lookup_key'    # JSON when piped
```

Same command, two contexts. Same theme as the other demos (Catppuccin Mocha / zsh / `$` prompt) for visual consistency.

### `demo/README.md`

Per-tape table goes 3 → 4 rows; init.tape description now mentions the agent/sandbox proof; regen block lists the new `vhs pipe-flow.tape` line.

## Gifs

Intentionally NOT in this PR. The author re-records locally:

```sh
brew upgrade akshitkrnagpal/tap/revcat   # ensure v0.6.0
export REVCAT_REFRESH_TOKEN=rtk_...
export REVCAT_PROJECT_ID=proj_...
cd demo
vhs init.tape
vhs pipe-flow.tape
```

Both tapes work against any project that has at least one offering. No placeholders to edit.

## Verification

- `make drift-check` clean
- Tapes manually verified against `revcat offerings list --help` and the existing `unset` shell builtin

## Merge gate

**Do not merge** until the gifs are committed on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akshitkrnagpal/codesmith/revcat/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->