### PR TITLE
[codex] Paginate subscription and purchase searches

### DIFF
--- a/internal/api/subscriptions.go
+++ b/internal/api/subscriptions.go
@@ -10,18 +10,18 @@ import (
 // SubscriptionFull is the full v2 subscription record (more fields than the
 // embedded Subscription type used in customer snapshots).
 type SubscriptionFull struct {
-	ID                 string   `json:"id"`
-	Status             string   `json:"status"`
-	ProductID          string   `json:"product_id"`
-	Store              string   `json:"store"`
-	StartsAt           int64    `json:"starts_at"`
-	CurrentEndsAt      int64    `json:"current_period_ends_at,omitempty"`
-	WillRenew          bool     `json:"will_renew"`
-	IsTrial            bool     `json:"is_in_trial_period"`
-	IsSandbox          bool     `json:"is_sandbox"`
-	UnsubscribeAt      int64    `json:"unsubscribe_detected_at,omitempty"`
-	CustomerID         string   `json:"customer_id,omitempty"`
-	EntitlementIDs     []string `json:"entitlement_ids,omitempty"`
+	ID             string   `json:"id"`
+	Status         string   `json:"status"`
+	ProductID      string   `json:"product_id"`
+	Store          string   `json:"store"`
+	StartsAt       int64    `json:"starts_at"`
+	CurrentEndsAt  int64    `json:"current_period_ends_at,omitempty"`
+	WillRenew      bool     `json:"will_renew"`
+	IsTrial        bool     `json:"is_in_trial_period"`
+	IsSandbox      bool     `json:"is_sandbox"`
+	UnsubscribeAt  int64    `json:"unsubscribe_detected_at,omitempty"`
+	CustomerID     string   `json:"customer_id,omitempty"`
+	EntitlementIDs []string `json:"entitlement_ids,omitempty"`
 }
 
 // Transaction is a single billing event under a subscription.
@@ -129,19 +129,23 @@ func (c *Client) SearchSubscriptions(ctx context.Context, query string) ([]Subsc
 	q := url.Values{}
 	q.Set("query", query)
 	q.Set("limit", "100")
-	path := c.projectPath("/subscriptions/search?" + q.Encode())
-	var page listResp[SubscriptionFull]
-	if err := c.Do(ctx, "GET", path, nil, &page); err != nil {
-		var apiErr *APIError
-		if errors.As(err, &apiErr) && apiErr.IsNotFound() {
-			return []SubscriptionFull{}, nil
+	all := []SubscriptionFull{}
+	for {
+		path := c.projectPath("/subscriptions/search?" + q.Encode())
+		var page listResp[SubscriptionFull]
+		if err := c.Do(ctx, "GET", path, nil, &page); err != nil {
+			var apiErr *APIError
+			if errors.As(err, &apiErr) && apiErr.IsNotFound() {
+				return []SubscriptionFull{}, nil
+			}
+			return nil, err
 		}
-		return nil, err
+		all = append(all, page.Items...)
+		if page.Next == "" {
+			return all, nil
+		}
+		q.Set("starting_after", page.Next)
 	}
-	if page.Items == nil {
-		return []SubscriptionFull{}, nil
-	}
-	return page.Items, nil
 }
 
 // PurchaseFull is the full v2 non-renewing purchase record.
@@ -213,19 +217,23 @@ func (c *Client) SearchPurchases(ctx context.Context, query string) ([]PurchaseF
 	q := url.Values{}
 	q.Set("query", query)
 	q.Set("limit", "100")
-	path := c.projectPath("/purchases/search?" + q.Encode())
-	var page listResp[PurchaseFull]
-	if err := c.Do(ctx, "GET", path, nil, &page); err != nil {
-		var apiErr *APIError
-		if errors.As(err, &apiErr) && apiErr.IsNotFound() {
-			return []PurchaseFull{}, nil
+	all := []PurchaseFull{}
+	for {
+		path := c.projectPath("/purchases/search?" + q.Encode())
+		var page listResp[PurchaseFull]
+		if err := c.Do(ctx, "GET", path, nil, &page); err != nil {
+			var apiErr *APIError
+			if errors.As(err, &apiErr) && apiErr.IsNotFound() {
+				return []PurchaseFull{}, nil
+			}
+			return nil, err
 		}
-		return nil, err
+		all = append(all, page.Items...)
+		if page.Next == "" {
+			return all, nil
+		}
+		q.Set("starting_after", page.Next)
 	}
-	if page.Items == nil {
-		return []PurchaseFull{}, nil
-	}
-	return page.Items, nil
 }
 
 // GetInvoice fetches one invoice by id.

--- a/internal/api/subscriptions_test.go
+++ b/internal/api/subscriptions_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSearchSubscriptionsPaginates(t *testing.T) {
+	var starts []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/projects/proj_xyz/subscriptions/search" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("query"); got != "store_123" {
+			t.Fatalf("query: want store_123, got %q", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "100" {
+			t.Fatalf("limit: want 100, got %q", got)
+		}
+
+		startingAfter := r.URL.Query().Get("starting_after")
+		starts = append(starts, startingAfter)
+		w.Header().Set("Content-Type", "application/json")
+		if startingAfter == "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items":     []map[string]any{{"id": "sub_1"}},
+				"next_page": "cursor_1",
+			})
+			return
+		}
+		if startingAfter != "cursor_1" {
+			t.Fatalf("starting_after: want cursor_1, got %q", startingAfter)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{{"id": "sub_2"}},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(Options{TokenSource: stubToken("sk"), ProjectID: "proj_xyz", BaseURL: srv.URL})
+	got, err := c.SearchSubscriptions(context.Background(), "store_123")
+	if err != nil {
+		t.Fatalf("SearchSubscriptions: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "sub_1" || got[1].ID != "sub_2" {
+		t.Fatalf("unexpected subscriptions: %+v", got)
+	}
+	if len(starts) != 2 || starts[0] != "" || starts[1] != "cursor_1" {
+		t.Fatalf("unexpected pagination cursors: %#v", starts)
+	}
+}
+
+func TestSearchPurchasesPaginates(t *testing.T) {
+	var starts []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/projects/proj_xyz/purchases/search" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("query"); got != "store_123" {
+			t.Fatalf("query: want store_123, got %q", got)
+		}
+
+		startingAfter := r.URL.Query().Get("starting_after")
+		starts = append(starts, startingAfter)
+		w.Header().Set("Content-Type", "application/json")
+		if startingAfter == "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items":     []map[string]any{{"id": "pur_1"}},
+				"next_page": "cursor_1",
+			})
+			return
+		}
+		if startingAfter != "cursor_1" {
+			t.Fatalf("starting_after: want cursor_1, got %q", startingAfter)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{{"id": "pur_2"}},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(Options{TokenSource: stubToken("sk"), ProjectID: "proj_xyz", BaseURL: srv.URL})
+	got, err := c.SearchPurchases(context.Background(), "store_123")
+	if err != nil {
+		t.Fatalf("SearchPurchases: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "pur_1" || got[1].ID != "pur_2" {
+		t.Fatalf("unexpected purchases: %+v", got)
+	}
+	if len(starts) != 2 || starts[0] != "" || starts[1] != "cursor_1" {
+		t.Fatalf("unexpected pagination cursors: %#v", starts)
+	}
+}


### PR DESCRIPTION
## Summary

Follow `next_page` cursors for `SearchSubscriptions` and `SearchPurchases` by passing `starting_after` on subsequent requests.

## Why

The search helpers previously returned only the first page, which could silently truncate results at 100 and mislead CLI users or automation.

## Validation

- `go test ./internal/api -run 'TestSearch(Subscriptions|Purchases)Paginates' -v`
- `make verify`