### PR TITLE
[codex] Clarify init app selection prompt

### DIFF
--- a/commands/initcmd/init.go
+++ b/commands/initcmd/init.go
@@ -247,7 +247,7 @@ func pickApps(parent context.Context, cmd *cobra.Command, resolved *authstore.Re
 	}
 	var picked []int
 	if err := survey.AskOne(&survey.MultiSelect{
-		Message: "Which apps to record? (space to toggle, enter to confirm; leave empty to skip)",
+		Message: "Which apps to record? (all selected by default; space to toggle, enter to confirm)",
 		Options: options,
 		Default: defaults,
 	}, &picked); err != nil {


### PR DESCRIPTION
## Summary

Update the interactive `revcat init` app-selection prompt to say that all apps are selected by default.

## Why

The previous prompt said "leave empty to skip" even though the multiselect default selected every app, making the behavior easy to misread during interactive or agent-assisted setup.

## Validation

- `make verify`