### PR TITLE
[codex] Approve docs build dependencies

### DIFF
--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
## Summary

Commit pnpm 11 build-script approvals for the docs project dependencies that need install scripts: `esbuild` and `sharp`.

## Why

Without the approval file, `pnpm install --frozen-lockfile` and `pnpm build` fail non-interactively with `ERR_PNPM_IGNORED_BUILDS`, which blocks agent and CI docs verification.

## Validation

- `pnpm approve-builds esbuild sharp`
- `pnpm build`
- `make verify`