### PR TITLE
[codex] Add CI verification workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  go:
+    name: Go verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify
+        run: make verify
+
+  docs:
+    name: Docs build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.0.1
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: docs/pnpm-lock.yaml
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary

Add GitHub Actions CI with two checks:

- Go verification via `make verify`
- Docs verification via `pnpm install --frozen-lockfile` and `pnpm build`

## Why

The repo had strong local verification commands, but no hosted gate under `.github/workflows`, so regressions were only caught when a maintainer or agent remembered to run local checks.

## Validation

- `make verify`
- `pnpm install --frozen-lockfile && pnpm build`

## Note

Replacement for the stacked #60 after #59 was merged into `main`. This PR is based directly on `main` and only adds the CI workflow.