### PR TITLE
fix(products): remind Test Store users to set prices

### DIFF
--- a/commands/products/products.go
+++ b/commands/products/products.go
@@ -105,7 +105,11 @@ Example body:
       "type": "subscription",
       "display_name": "Monthly",
       "app_id": "app_xxx"
-    }`,
+    }
+
+For Test Store products, RevenueCat v2 does not expose price create/update
+endpoints. After creating the product, set its price in the RevenueCat
+dashboard or the SDK will not show packages that contain it.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		body, err := loadJSON(createFile)
 		if err != nil {
@@ -122,11 +126,20 @@ Example body:
 			return err
 		}
 		output.Success("created %s", p.ID)
+		if needsTestStorePriceReminder(body) {
+			output.Info("Test Store price reminder: RevenueCat v2 does not expose price create/update endpoints. Set the price in the RevenueCat dashboard before using this product from the SDK.")
+		}
 		if output.IsJSON() {
 			return output.JSON(p)
 		}
 		return nil
 	},
+}
+
+func needsTestStorePriceReminder(body map[string]any) bool {
+	_, hasTitle := body["title"]
+	_, hasDisplayName := body["display_name"]
+	return hasTitle && !hasDisplayName
 }
 
 func init() {

--- a/commands/products/products_test.go
+++ b/commands/products/products_test.go
@@ -1,0 +1,29 @@
+package products
+
+import "testing"
+
+func TestNeedsTestStorePriceReminderForTitleOnlyProduct(t *testing.T) {
+	body := map[string]any{
+		"store_identifier": "com.test.monthly",
+		"type":             "subscription",
+		"title":            "Monthly",
+		"app_id":           "app_xxx",
+	}
+
+	if !needsTestStorePriceReminder(body) {
+		t.Fatal("want reminder for Test Store-style product body with title and no display_name")
+	}
+}
+
+func TestNeedsTestStorePriceReminderSkipsDisplayNameProduct(t *testing.T) {
+	body := map[string]any{
+		"store_identifier": "app.monthly",
+		"type":             "subscription",
+		"display_name":     "Monthly",
+		"app_id":           "app_xxx",
+	}
+
+	if needsTestStorePriceReminder(body) {
+		t.Fatal("do not want reminder for regular store product body with display_name")
+	}
+}

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -1254,6 +1254,10 @@ Example body:
       "display_name": "Monthly",
       "app_id": "app_xxx"
     }
+
+For Test Store products, RevenueCat v2 does not expose price create/update
+endpoints. After creating the product, set its price in the RevenueCat
+dashboard or the SDK will not show packages that contain it.
 ```
 
 **Usage**


### PR DESCRIPTION
## Summary
- Add a `products create` reminder for Test Store-style product bodies that RevenueCat v2 cannot set prices
- Document the dashboard-only price step in generated CLI reference
- Cover the reminder heuristic with products command tests

Fixes #29

## Test Plan
- `go test ./commands/products -run TestNeedsTestStorePriceReminder -count=1`
- `go test ./...`
- `go vet ./...`
- `make drift-check`